### PR TITLE
Removed erroneous h7 cfg line in adc.rs which was preventing all adc …

### DIFF
--- a/examples/adc.rs
+++ b/examples/adc.rs
@@ -14,7 +14,7 @@ use cortex_m::{
 use cortex_m_rt::entry;
 
 use stm32_hal2::{
-    adc::{Adc, AdcChannel, AdcDevice, AdcInterrupt, Align, ClockMode, InputType, OperationMode},
+    adc::{Adc, AdcChannel, AdcDevice, AdcInterrupt, Align, ClockMode, InputType, OperationMode, SampleTime},
     clocks::Clocks,
     dma::{self, Dma, DmaChannel, DmaInterrupt, DmaWriteBuf},
     gpio::{Pin, PinMode, Port},

--- a/src/adc.rs
+++ b/src/adc.rs
@@ -72,7 +72,7 @@ pub enum AdcDevice {
 pub enum AdcInterrupt {
     Ready,
     EndOfConversion,
-    EnfOfSequence,
+    EndOfSequence,
     EndofConversionInjected,
     EndOfSequenceInjected,
     Watchdog1,
@@ -916,7 +916,7 @@ macro_rules! hal {
                 self.regs.ier.modify(|_, w| match interrupt {
                     AdcInterrupt::Ready => w.adrdyie().set_bit(),
                     AdcInterrupt::EndOfConversion => w.eocie().set_bit(),
-                    AdcInterrupt::EnfOfSequence => w.eosie().set_bit(),
+                    AdcInterrupt::EndOfSequence => w.eosie().set_bit(),
                     AdcInterrupt::EndofConversionInjected => w.jeocie().set_bit(),
                     AdcInterrupt::EndOfSequenceInjected => w.jeosie().set_bit(),
                     AdcInterrupt::Watchdog1 => w.awd1ie().set_bit(),
@@ -934,7 +934,7 @@ macro_rules! hal {
                 self.regs.isr.modify(|_, w| match interrupt {
                     AdcInterrupt::Ready =>  w.adrdy().set_bit(),
                     AdcInterrupt::EndOfConversion =>  w.eoc().set_bit(),
-                    AdcInterrupt::EnfOfSequence =>  w.eos().set_bit(),
+                    AdcInterrupt::EndOfSequence =>  w.eos().set_bit(),
                     AdcInterrupt::EndofConversionInjected =>  w.jeoc().set_bit(),
                     AdcInterrupt::EndOfSequenceInjected =>  w.jeos().set_bit(),
                     AdcInterrupt::Watchdog1 =>  w.awd1().set_bit(),
@@ -947,7 +947,7 @@ macro_rules! hal {
                 // match interrupt {
                 //     AdcInterrupt::Ready => self.regs.icr.write(|_w| w.adrdy().set_bit()),
                 //     AdcInterrupt::EndOfConversion => self.regs.icr.write(|w| w.eoc().set_bit()),
-                //     AdcInterrupt::EnfOfSequence => self.regs.icr.write(|_w| w.eos().set_bit()),
+                //     AdcInterrupt::EndOfSequence => self.regs.icr.write(|_w| w.eos().set_bit()),
                 //     AdcInterrupt::EndofConversionInjected => self.regs.icr.write(|_w| w.jeoc().set_bit()),
                 //     AdcInterrupt::EndOfSequenceInjected => self.regs.icr.write(|_w| w.jeos().set_bit()),
                 //     AdcInterrupt::Watchdog1 => self.regs.icr.write(|_w| w.awd1().set_bit()),

--- a/src/adc.rs
+++ b/src/adc.rs
@@ -1138,7 +1138,6 @@ cfg_if! {
     }
 }
 
-#[cfg(feature = "h7")]
 
 cfg_if! {
     if #[cfg(feature = "g4")] {


### PR DESCRIPTION
Removed erroneous h7 cfg line in adc.rs which was preventing all adc functionality on the g4 series.

I'm a beginner when it comes to rust, but it seems like this is correct. Please feedback if I'm wrong.