### PR TITLE
fix compile on stm32l4

### DIFF
--- a/src/can.rs
+++ b/src/can.rs
@@ -40,7 +40,7 @@ where
     #[cfg(not(feature = "f4"))]
     /// Initialize a CAH peripheral, including  enabling and resetting
     /// its RCC peripheral clock.
-    pub fn new<P>(regs: R, rcc: &mut RCC) -> Self {
+    pub fn new(regs: R, rcc: &mut RCC) -> Self {
         #[cfg(feature = "f3")]
         rcc_en_reset!(apb1, can, rcc);
         #[cfg(feature = "l4")]


### PR DESCRIPTION
To compile my project I had to modify this line. I don't know what was used for.

I was thinking if it is better to update this library to cover the new bxcan 0.6 that have a clearer interface.