### PR TITLE
Added L4 pllp configuration

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -105,6 +105,7 @@ l412 = ["stm32l4/stm32l412", "l4"]
 l4x3 = ["stm32l4/stm32l4x3", "l4"]
 l4x5 = ["stm32l4/stm32l4x5", "l4"]
 l4x6 = ["stm32l4/stm32l4x6", "l4"]
+l496 = ["l4x6", "pllpdiv"]
 # todo: Handle l4+ (P, R, S, Q)
 
 # [L5](https://docs.rs/crate/stm32l5/latest/source/Cargo.toml)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -105,7 +105,6 @@ l412 = ["stm32l4/stm32l412", "l4"]
 l4x3 = ["stm32l4/stm32l4x3", "l4"]
 l4x5 = ["stm32l4/stm32l4x5", "l4"]
 l4x6 = ["stm32l4/stm32l4x6", "l4"]
-l496 = ["l4x6", "pllpdiv"]
 # todo: Handle l4+ (P, R, S, Q)
 
 # [L5](https://docs.rs/crate/stm32l5/latest/source/Cargo.toml)

--- a/src/clocks/baseline.rs
+++ b/src/clocks/baseline.rs
@@ -1363,12 +1363,12 @@ impl Clocks {
 
         match self.sai1_src {
             SaiSrc::PllSai1P => {
-                input_freq / self.pll.divm.value() as u32 * self.pll.divn as u32
-                    / self.pll.divp.value() as u32
-            }
-            SaiSrc::Pllp => {
                 input_freq / self.pll.divm.value() as u32 * self.pllsai1.divn as u32
                     / self.pllsai1.divp.value() as u32
+            }
+            SaiSrc::Pllp => {
+                input_freq / self.pll.divm.value() as u32 * self.pll.divn as u32
+                    / self.pll.divp.value() as u32
             }
             SaiSrc::Hsi => 16_000_000,
             SaiSrc::ExtClk => unimplemented!(),
@@ -1406,6 +1406,14 @@ impl Clocks {
             || self.pllsai1.divn > 86
         {
             return Err(SpeedError::new("A PLL divider is out of limits"));
+        }
+
+        #[cfg(any(feature = "l4x6"))]
+        if matches!(self.pll.divp, Pllp::Extended(1))
+            || matches!(self.pllsai1.divp, Pllp::Extended(1))
+            || matches!(self.pllsai2.divp, Pllp::Extended(1))
+        {
+            return Err(SpeedError::new("A Pllp divider is invalid"));
         }
 
         #[cfg(feature = "g0")]


### PR DESCRIPTION
The plls in L4s have p divider configurations that are composed from two different components (RM0351, Section 6).  There is a pllp value, which is a single bit and sets the divider to 7 when 0, and 17 when 1.  Some variants also have a pdiv value which is a standard divider.  If pdiv is set to 0 pllp is used, and pdiv shouldn't be set to 1.

Changes:
- Added Pllp enum to represent the combination of pllp and pdiv values.
- Fixed speed calculation if PllSai1P is selected as the sai1_src
- Added validation to enforce that pdiv shouldn't be 1