### PR TITLE
Fixed broken G0 builds

### DIFF
--- a/src/clocks/baseline.rs
+++ b/src/clocks/baseline.rs
@@ -880,8 +880,7 @@ impl Clocks {
                         w.pllm().bits(self.pll.divm as u8);
                         w.pllr().bits(self.pll.divr as u8);
                         w.pllq().bits(self.pll.divq as u8);
-                        w.pllp().bit(self.pll.divp as u8 != 0);
-                        w.pllpdiv().bits(self.pll.pdiv)
+                        w.pllp().bits(self.pll.divp as u8)
                     });
                 } else {
                     rcc.pllcfgr.modify(|_, w| unsafe {


### PR DESCRIPTION
I broke the G0 variants with my last PR.  Fixed the PLLP change for G0.

Changes:
- Set pllp as a u8 instead of a boolean in the G0 specific pll config section.

Testing:
- Compiled for g030, g031, g041, g070, g071, g081