### PR TITLE
usbotg work, fixed build for f4 and l4x6

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -507,6 +507,7 @@ cfg_if::cfg_if! {
                 feature = "l4x2",
                 feature = "l412",
                 feature = "l4x3",
+                feature = "l4x5",
                 feature = "l5",
                 feature = "g4",
                 feature = "wb",
@@ -517,7 +518,7 @@ cfg_if::cfg_if! {
     } else if #[cfg(all(
     // todo: I think only H7 has hs (high-speed), while F4 and L4 have FS only.
         any(feature = "usbotg_fs", feature = "usbotg_hs"),
-        any(feature = "f4", feature = "l4x5", feature = "l4x6", feature = "h7")
+        any(feature = "f4", feature = "l4x6", feature = "h7")
     ))] {
         pub mod usb_otg; // todo: A way to export it as `usb`?
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -518,7 +518,8 @@ cfg_if::cfg_if! {
     } else if #[cfg(all(
     // todo: I think only H7 has hs (high-speed), while F4 and L4 have FS only.
         any(feature = "usbotg_fs", feature = "usbotg_hs"),
-        any(feature = "f4", feature = "l4x6", feature = "h7")
+        any(feature = "f4", feature = "l4x6", feature = "h7"),
+        not(feature = "f410")
     ))] {
         pub mod usb_otg; // todo: A way to export it as `usb`?
     }

--- a/src/usb.rs
+++ b/src/usb.rs
@@ -3,9 +3,20 @@
 //!
 //! Requires the `usb` feature.
 //!
-//! Used on F303, L4x2, L4x3, L5, G0, and G4. F4, L4x5, L4x6 and H7 use the `usb_otg` module.
+//! Used on F303, L4x2, L4x3, L4x5, L5, G0, and G4. F4, L4x6 and H7 use the `usb_otg` module.
 //! For G0 series, USB is only available on G0B0, G0B1, G0C1, which the PAC doesn't yet differentiate,
 //! and this library doesn't yet support.
+
+/* 
+ Small caveat, the pac for the l4x5 exposes a USB peripheral instead
+ of a OTG peripheral, even though this chart
+ https://www.st.com/en/microcontrollers-microprocessors/stm32l4-series.html
+ shows that the stm32l475 has OTG.
+
+ Further inspection shows that the generated pac for the l4x5 has a USB peripheral
+ while the l4r5 has an OTG, but this crate doesn't currently seem to support the 
+ l4r5 variant.
+*/
 
 use crate::{pac, util::rcc_en_reset};
 

--- a/src/usb_otg.rs
+++ b/src/usb_otg.rs
@@ -111,8 +111,11 @@ macro_rules! usb_peripheral {
 
                 cortex_m::interrupt::free(|_| {
                     // USB Regulator in BYPASS mode
-                    #[cfg(feature = "h7")] // only h7 seems to have this
+                    #[cfg(feature = "h7")]
                     pwr.cr3.modify(|_, w| w.usb33den().set_bit());
+                    #[cfg(feature = "l4x6")] // this was present in the usb module
+                    pwr.cr2.modify(|_, w| w.usv().set_bit());
+                    // The f4 doesn't seem to have anything similar
 
                     // Enable USB peripheral
                     rcc.$clock_enable_reg.modify(|_, w| w.$en().set_bit());


### PR DESCRIPTION
The usbotg_fs feature now works as intended

updated documentation, the l4x5 does not have otg support

updated feature gating for boards without the necessary peripherals

it currently compiles for all f4, l4x6 and h7 targets (except h7b3 which is broken elsewhere)

tested on stm32f411ceu6, no obvious problems