### PR TITLE
L4+ support (focussed on L4P5 / L4Q5)

### DIFF
--- a/.idea/stm32-hal.iml
+++ b/.idea/stm32-hal.iml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <module type="PYTHON_MODULE" version="4">
+  <component name="Go" enabled="true" />
   <component name="NewModuleRootManager">
     <content url="file://$MODULE_DIR$">
       <sourceFolder url="file://$MODULE_DIR$/examples" isTestSource="false" />

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ cortex-m = "0.7.3"
 # Peripheral Access Crates
 stm32f3 = { version = "0.15.1", optional = true }
 stm32f4 = { version = "0.15.1", optional = true }
-stm32l4 = { version = "0.15.1", optional = true }
+stm32l4 = { path = "../stm32-rs/stm32l4", optional = true }
 stm32l5 = { version = "0.15.1", optional = true }
 stm32g0 = { version = "0.15.1", optional = true }
 stm32g4 = { version = "0.15.1", optional = true }
@@ -107,6 +107,8 @@ l4x5 = ["stm32l4/stm32l4x5", "l4"]
 l4x6 = ["stm32l4/stm32l4x6", "l4"]
 # todo: Handle l4+ (P, R, S, Q)
 
+l4p5 = ["stm32l4/stm32l4p5", "l4p"]
+
 # [L5](https://docs.rs/crate/stm32l5/latest/source/Cargo.toml)
 l552 = ["stm32l5/stm32l552", "l5"]
 l562 = ["stm32l5/stm32l562", "l5"]
@@ -165,6 +167,7 @@ embedded_hal = ["embedded-hal", "nb"]
 f3 = []
 f4 = []
 l4 = []
+l4p = []
 l5 = []
 g0 = []
 g4 = []

--- a/src/adc.rs
+++ b/src/adc.rs
@@ -870,7 +870,7 @@ macro_rules! hal {
 
                 // L44 RM, Table 41. "DMA1 requests for each channel
                 // todo: DMA2 support.
-                #[cfg(any(feature = "f3", feature = "l4"))]
+                #[cfg(any(feature = "f3", all(feature = "l4", not(feature = "l4plus"))))]
                 let dma_channel = match self.device {
                     AdcDevice::One => DmaInput::Adc1.dma1_channel(),
                     AdcDevice::Two => DmaInput::Adc2.dma1_channel(),
@@ -878,7 +878,7 @@ macro_rules! hal {
                 or PR on Github.")
                 };
 
-                #[cfg(feature = "l4")]
+                #[cfg(all(feature = "l4", not(feature = "l4plus")))]
                 match self.device {
                     AdcDevice::One => dma.channel_select(DmaInput::Adc1),
                     AdcDevice::Two => dma.channel_select(DmaInput::Adc2),

--- a/src/clocks/mod.rs
+++ b/src/clocks/mod.rs
@@ -17,7 +17,7 @@ cfg_if::cfg_if! {
     if #[cfg(any(feature = "f3", feature = "f4"))] {
         mod f;
         pub use f::*;
-    } else if #[cfg(any(feature = "l4", feature = "l5", feature = "g0", feature = "g4", feature = "wb", feature = "wl"))] {
+    } else if #[cfg(any(feature = "l4", feature = "l4p", feature = "l5", feature = "g0", feature = "g4", feature = "wb", feature = "wl"))] {
         mod baseline;
         pub use baseline::*;
     } else if #[cfg(feature = "u5")] {

--- a/src/crc.rs
+++ b/src/crc.rs
@@ -20,7 +20,7 @@ impl CrcExt for CRC {
             if #[cfg(feature = "f3")] {
                 rcc.ahbenr.modify(|_, w| w.crcen().set_bit());
                 // F3 doesn't appear to have a crcrst field in `ahbrstr`, per RM.
-            } else if #[cfg(any(feature = "l4", feature = "wb"))] {
+            } else if #[cfg(any(feature = "l4", feature = "l4p", feature = "wb"))] {
                 rcc.ahb1enr.modify(|_, w| w.crcen().set_bit());
                 rcc.ahb1rstr.modify(|_, w| w.crcrst().set_bit());
                 rcc.ahb1rstr.modify(|_, w| w.crcrst().clear_bit());
@@ -157,7 +157,7 @@ impl Crc {
             ///
             /// The IDR is not involved with CRC calculation.
             pub fn set_idr(&mut self, value: u8) {
-                self.reg.idr.write(|w| w.idr().bits(value));
+                self.reg.idr.write(|w| unsafe { w.idr().bits(value) });
             }
         }
     }

--- a/src/dac.rs
+++ b/src/dac.rs
@@ -347,13 +347,13 @@ where
     {
         let (ptr, len) = (buf.as_ptr(), buf.len());
 
-        #[cfg(any(feature = "f3", feature = "l4"))]
+        #[cfg(any(feature = "f3", all(feature = "l4", not(feature = "l4plus"))))]
         let dma_channel = match dac_channel {
             DacChannel::C1 => DmaInput::Dac1Ch1.dma1_channel(),
             DacChannel::C2 => DmaInput::Dac1Ch2.dma1_channel(),
         };
 
-        #[cfg(feature = "l4")]
+        #[cfg(all(feature = "l4", not(feature = "l4plus")))]
         match dac_channel {
             DacChannel::C1 => dma.channel_select(DmaInput::Dac1Ch1),
             DacChannel::C2 => dma.channel_select(DmaInput::Dac1Ch2),

--- a/src/dfsdm.rs
+++ b/src/dfsdm.rs
@@ -14,7 +14,7 @@ use crate::{clocks::Clocks, pac::RCC, util::rcc_en_reset};
 use cfg_if::cfg_if;
 
 cfg_if! {
-    if #[cfg(any(feature = "l4", feature = "l5", feature = "h7b3"))] {
+    if #[cfg(any(feature = "l4", feature = "l4p", feature = "l5", feature = "h7b3"))] {
         use crate::pac::dfsdm1 as dfsdm_p;
     } else {
         use crate::pac::dfsdm as dfsdm_p;
@@ -248,10 +248,10 @@ where
         cfg_if! {
             if #[cfg(any(feature = "l5"))] {
                 let cfgr1 = &regs.ch0cfgr1;
-            } else if #[cfg(any(feature = "l4"))] {
+            } else if #[cfg(feature = "l4")] {
                 let cfgr1 = &regs.chcfg0r1;
             } else {
-                let cfgr1 = &regs.ch0.cfgr1;
+                let cfgr1 = &regs.ch[0].cfgr1;
             }
         }
 
@@ -295,10 +295,10 @@ where
         cfg_if! {
             if #[cfg(any(feature = "l5"))] {
                 let cfgr1 = &self.regs.ch0cfgr1;
-            } else if #[cfg(any(feature = "l4"))] {
+            } else if #[cfg(feature = "l4")] {
                 let cfgr1 = &self.regs.chcfg0r1;
             } else {
-                let cfgr1 = &self.regs.ch0.cfgr1;
+                let cfgr1 = &self.regs.ch[0].cfgr1;
             }
         }
         cfgr1.modify(|_, w| w.dfsdmen().set_bit());
@@ -311,10 +311,10 @@ where
         cfg_if! {
             if #[cfg(any(feature = "l5"))] {
                 let cfgr1 = &self.regs.ch0cfgr1;
-            } else if #[cfg(any(feature = "l4"))] {
+            } else if #[cfg(feature = "l4")] {
                 let cfgr1 = &self.regs.chcfg0r1;
             } else {
-                let cfgr1 = &self.regs.ch0.cfgr1;
+                let cfgr1 = &self.regs.ch[0].cfgr1;
             }
         }
         cfgr1.modify(|_, w| w.dfsdmen().clear_bit());
@@ -384,12 +384,12 @@ where
                     if #[cfg(any(feature = "l5"))] {
                         let fcr = &self.regs.flt0fcr;
                         let cr1 = &self.regs.flt0cr1;
-                    } else if #[cfg(any(feature = "l4"))] {
+                    } else if #[cfg(feature = "l4")] {
                         let fcr = &self.regs.dfsdm0_fcr;
                         let cr1 = &self.regs.dfsdm0_cr1;
                     } else {
-                        let fcr = &self.regs.flt0.fcr;
-                        let cr1 = &self.regs.flt0.cr1;
+                        let fcr = &self.regs.flt[0].fcr;
+                        let cr1 = &self.regs.flt[0].cr1;
                     }
                 }
                 fcr.modify(|_, w| unsafe {
@@ -413,12 +413,12 @@ where
                     if #[cfg(any(feature = "l5"))] {
                         let fcr = &self.regs.flt1fcr;
                         let cr1 = &self.regs.flt1cr1;
-                    } else if #[cfg(any(feature = "l4"))] {
-                        // let fcr = &self.regs.dfsdm1_fcr;
-                        // let cr1 = &self.regs.dfsdm1_cr1;
+                    } else if #[cfg(feature = "l4")] {
+                        let fcr = &self.regs.dfsdm1_fcr;
+                        let cr1 = &self.regs.dfsdm1_cr1;
                     } else {
-                        let fcr = &self.regs.flt1.fcr;
-                        let cr1 = &self.regs.flt1.cr1;
+                        let fcr = &self.regs.flt[1].fcr;
+                        let cr1 = &self.regs.flt[1].cr1;
                     }
                 }
 
@@ -440,12 +440,12 @@ where
                     if #[cfg(any(feature = "l5"))] {
                         let fcr = &self.regs.flt2fcr;
                         let cr1 = &self.regs.flt2cr1;
-                    }  else if #[cfg(any(feature = "l4"))] {
+                    }  else if #[cfg(feature = "l4")] {
                         let fcr = &self.regs.dfsdm2_fcr;
                         let cr1 = &self.regs.dfsdm2_cr1;
                     } else {
-                        let fcr = &self.regs.flt2.fcr;
-                        let cr1 = &self.regs.flt2.cr1;
+                        let fcr = &self.regs.flt[2].fcr;
+                        let cr1 = &self.regs.flt[2].cr1;
                     }
                 }
 
@@ -467,12 +467,12 @@ where
                     if #[cfg(any(feature = "l5"))] {
                         let fcr = &self.regs.flt3fcr;
                         let cr1 = &self.regs.flt3cr1;
-                    } else if #[cfg(any(feature = "l4"))] {
+                    } else if #[cfg(feature = "l4")] {
                         let fcr = &self.regs.dfsdm3_fcr;
                         let cr1 = &self.regs.dfsdm3_cr1;
                     } else {
-                        let fcr = &self.regs.flt3.fcr;
-                        let cr1 = &self.regs.flt3.cr1;
+                        let fcr = &self.regs.flt[3].fcr;
+                        let cr1 = &self.regs.flt[3].cr1;
                     }
                 }
                 fcr.modify(|_, w| unsafe {
@@ -504,12 +504,12 @@ where
                     if #[cfg(any(feature = "l5"))] {
                         let cfgr1 = &self.regs.ch0cfgr1;
                         let cfgr2 = &self.regs.ch0cfgr2;
-                    } else if #[cfg(any(feature = "l4"))] {
+                    } else if #[cfg(feature = "l4")] {
                         let cfgr1 = &self.regs.chcfg0r1;
                         let cfgr2 = &self.regs.chcfg0r2;
                     } else {
-                        let cfgr1 = &self.regs.ch0.cfgr1;
-                        let cfgr2 = &self.regs.ch0.cfgr2;
+                        let cfgr1 = &self.regs.ch[0].cfgr1;
+                        let cfgr2 = &self.regs.ch[0].cfgr2;
                     }
                 }
 
@@ -527,12 +527,12 @@ where
                     if #[cfg(any(feature = "l5"))] {
                         let cfgr1 = &self.regs.ch1cfgr1;
                         let cfgr2 = &self.regs.ch1cfgr2;
-                    } else if #[cfg(any(feature = "l4"))] {
+                    } else if #[cfg(feature = "l4")] {
                         let cfgr1 = &self.regs.chcfg1r1;
                         let cfgr2 = &self.regs.chcfg1r2;
                     } else {
-                        let cfgr1 = &self.regs.ch1.cfgr1;
-                        let cfgr2 = &self.regs.ch1.cfgr2;
+                        let cfgr1 = &self.regs.ch[1].cfgr1;
+                        let cfgr2 = &self.regs.ch[1].cfgr2;
                     }
                 }
 
@@ -550,12 +550,12 @@ where
                     if #[cfg(any(feature = "l5"))] {
                         let cfgr1 = &self.regs.ch2cfgr1;
                         let cfgr2 = &self.regs.ch2cfgr2;
-                    } else if #[cfg(any(feature = "l4"))] {
+                    } else if #[cfg(feature = "l4")] {
                         let cfgr1 = &self.regs.chcfg3r1;
                         let cfgr2 = &self.regs.chcfg3r2;
                     } else {
-                        let cfgr1 = &self.regs.ch2.cfgr1;
-                        let cfgr2 = &self.regs.ch2.cfgr2;
+                        let cfgr1 = &self.regs.ch[2].cfgr1;
+                        let cfgr2 = &self.regs.ch[2].cfgr2;
                     }
                 }
 
@@ -573,12 +573,12 @@ where
                     if #[cfg(any(feature = "l5"))] {
                         let cfgr1 = &self.regs.ch3cfgr1;
                         let cfgr2 = &self.regs.ch3cfgr2;
-                    } else if #[cfg(any(feature = "l4"))] {
+                    } else if #[cfg(feature = "l4")] {
                         let cfgr1 = &self.regs.chcfg3r1;
                         let cfgr2 = &self.regs.chcfg3r2;
                     } else {
-                        let cfgr1 = &self.regs.ch3.cfgr1;
-                        let cfgr2 = &self.regs.ch3.cfgr2;
+                        let cfgr1 = &self.regs.ch[3].cfgr1;
+                        let cfgr2 = &self.regs.ch[3].cfgr2;
                     }
                 }
 
@@ -596,12 +596,12 @@ where
                     if #[cfg(any(feature = "l5"))] {
                         let cfgr1 = &self.regs.ch4cfgr1;
                         let cfgr2 = &self.regs.ch4cfgr2;
-                    } else if #[cfg(any(feature = "l4"))] {
+                    } else if #[cfg(feature = "l4")] {
                         let cfgr1 = &self.regs.chcfg4r1;
                         let cfgr2 = &self.regs.chcfg4r2;
                     } else {
-                        let cfgr1 = &self.regs.ch4.cfgr1;
-                        let cfgr2 = &self.regs.ch4.cfgr2;
+                        let cfgr1 = &self.regs.ch[4].cfgr1;
+                        let cfgr2 = &self.regs.ch[4].cfgr2;
                     }
                 }
 
@@ -619,12 +619,12 @@ where
                     if #[cfg(any(feature = "l5"))] {
                         let cfgr1 = &self.regs.ch5cfgr1;
                         let cfgr2 = &self.regs.ch5cfgr2;
-                    } else if #[cfg(any(feature = "l4"))] {
+                    } else if #[cfg(feature = "l4")] {
                         let cfgr1 = &self.regs.chcfg5r1;
                         let cfgr2 = &self.regs.chcfg5r2;
                     } else {
-                        let cfgr1 = &self.regs.ch5.cfgr1;
-                        let cfgr2 = &self.regs.ch5.cfgr2;
+                        let cfgr1 = &self.regs.ch[5].cfgr1;
+                        let cfgr2 = &self.regs.ch[5].cfgr2;
                     }
                 }
 
@@ -642,12 +642,12 @@ where
                     if #[cfg(any(feature = "l5"))] {
                         let cfgr1 = &self.regs.ch6cfgr1;
                         let cfgr2 = &self.regs.ch6cfgr2;
-                    } else if #[cfg(any(feature = "l4"))] {
+                    } else if #[cfg(feature = "l4")] {
                         let cfgr1 = &self.regs.chcfg6r1;
                         let cfgr2 = &self.regs.chcfg6r2;
                     } else {
-                        let cfgr1 = &self.regs.ch6.cfgr1;
-                        let cfgr2 = &self.regs.ch6.cfgr2;
+                        let cfgr1 = &self.regs.ch[6].cfgr1;
+                        let cfgr2 = &self.regs.ch[6].cfgr2;
                     }
                 }
 
@@ -665,12 +665,12 @@ where
                     if #[cfg(any(feature = "l5"))] {
                         let cfgr1 = &self.regs.ch7cfgr1;
                         let cfgr2 = &self.regs.ch7cfgr2;
-                    } else if #[cfg(any(feature = "l4"))] {
+                    } else if #[cfg(feature = "l4")] {
                         let cfgr1 = &self.regs.chcfg7r1;
                         let cfgr2 = &self.regs.chcfg7r2;
                     } else {
-                        let cfgr1 = &self.regs.ch7.cfgr1;
-                        let cfgr2 = &self.regs.ch7.cfgr2;
+                        let cfgr1 = &self.regs.ch[7].cfgr1;
+                        let cfgr2 = &self.regs.ch[7].cfgr2;
                     }
                 }
 
@@ -696,10 +696,10 @@ where
                 cfg_if! {
                     if #[cfg(any(feature = "l5"))] {
                         let cr1 = &self.regs.flt0cr1;
-                    } else if #[cfg(any(feature = "l4"))] {
+                    } else if #[cfg(feature = "l4")] {
                         let cr1 = &self.regs.dfsdm0_cr1;
                     } else {
-                        let cr1 = &self.regs.flt0.cr1;
+                        let cr1 = &self.regs.flt[0].cr1;
                     }
                 }
                 cr1.modify(|_, w| w.dfen().clear_bit())
@@ -711,10 +711,10 @@ where
                 cfg_if! {
                     if #[cfg(any(feature = "l5"))] {
                         let cr1 = &self.regs.flt1cr1;
-                    } else if #[cfg(any(feature = "l4"))] {
-                        // let cr1 = &self.regs.dfsdm1_cr1;
+                    } else if #[cfg(feature = "l4")] {
+                        let cr1 = &self.regs.dfsdm1_cr1;
                     } else {
-                        let cr1 = &self.regs.flt1.cr1;
+                        let cr1 = &self.regs.flt[1].cr1;
                     }
                 }
                 cr1.modify(|_, w| w.dfen().clear_bit())
@@ -723,10 +723,10 @@ where
                 cfg_if! {
                     if #[cfg(any(feature = "l5"))] {
                         let cr1 = &self.regs.flt2cr1;
-                    } else if #[cfg(any(feature = "l4"))] {
+                    } else if #[cfg(feature = "l4")] {
                         let cr1 = &self.regs.dfsdm2_cr1;
                     } else {
-                        let cr1 = &self.regs.flt2.cr1;
+                        let cr1 = &self.regs.flt[2].cr1;
                     }
                 }
                 cr1.modify(|_, w| w.dfen().clear_bit())
@@ -735,10 +735,10 @@ where
                 cfg_if! {
                     if #[cfg(any(feature = "l5"))] {
                         let cr1 = &self.regs.flt3cr1;
-                    } else if #[cfg(any(feature = "l4"))] {
+                    } else if #[cfg(feature = "l4")] {
                         let cr1 = &self.regs.dfsdm3_cr1;
                     } else {
-                        let cr1 = &self.regs.flt3.cr1;
+                        let cr1 = &self.regs.flt[3].cr1;
                     }
                 }
                 cr1.modify(|_, w| w.dfen().clear_bit())
@@ -760,12 +760,12 @@ where
                     if #[cfg(any(feature = "l5"))] {
                         let cfgr1 = &self.regs.ch0cfgr1;
                         let cfgr1b = &self.regs.ch7cfgr1;
-                    } else if #[cfg(any(feature = "l4"))] {
+                    } else if #[cfg(feature = "l4")] {
                         let cfgr1 = &self.regs.chcfg0r1;
                         let cfgr1b = &self.regs.chcfg7r1;
                     } else {
-                        let cfgr1 = &self.regs.ch0.cfgr1;
-                        let cfgr1b = &self.regs.ch7.cfgr1;
+                        let cfgr1 = &self.regs.ch[0].cfgr1;
+                        let cfgr1b = &self.regs.ch[7].cfgr1;
                     }
                 }
 
@@ -792,12 +792,12 @@ where
                     if #[cfg(any(feature = "l5"))] {
                         let cfgr1 = &self.regs.ch1cfgr1;
                         let cfgr1b = &self.regs.ch0cfgr1;
-                    } else if #[cfg(any(feature = "l4"))] {
+                    } else if #[cfg(feature = "l4")] {
                         let cfgr1 = &self.regs.chcfg1r1;
                         let cfgr1b = &self.regs.chcfg0r1;
                     } else {
-                        let cfgr1 = &self.regs.ch1.cfgr1;
-                        let cfgr1b = &self.regs.ch0.cfgr1;
+                        let cfgr1 = &self.regs.ch[1].cfgr1;
+                        let cfgr1b = &self.regs.ch[0].cfgr1;
                     }
                 }
 
@@ -816,12 +816,12 @@ where
                     if #[cfg(any(feature = "l5"))] {
                         let cfgr1 = &self.regs.ch2cfgr1;
                         let cfgr1b = &self.regs.ch1cfgr1;
-                    } else if #[cfg(any(feature = "l4"))] {
+                    } else if #[cfg(feature = "l4")] {
                         let cfgr1 = &self.regs.chcfg2r1;
                         let cfgr1b = &self.regs.chcfg1r1;
                     } else {
-                        let cfgr1 = &self.regs.ch2.cfgr1;
-                        let cfgr1b = &self.regs.ch1.cfgr1;
+                        let cfgr1 = &self.regs.ch[2].cfgr1;
+                        let cfgr1b = &self.regs.ch[1].cfgr1;
                     }
                 }
 
@@ -840,12 +840,12 @@ where
                     if #[cfg(any(feature = "l5"))] {
                         let cfgr1 = &self.regs.ch3cfgr1;
                         let cfgr1b = &self.regs.ch2cfgr1;
-                    } else if #[cfg(any(feature = "l4"))] {
+                    } else if #[cfg(feature = "l4")] {
                         let cfgr1 = &self.regs.chcfg3r1;
                         let cfgr1b = &self.regs.chcfg2r1;
                     } else {
-                        let cfgr1 = &self.regs.ch3.cfgr1;
-                        let cfgr1b = &self.regs.ch2.cfgr1;
+                        let cfgr1 = &self.regs.ch[3].cfgr1;
+                        let cfgr1b = &self.regs.ch[2].cfgr1;
                     }
                 }
 
@@ -878,10 +878,10 @@ where
                 cfg_if! {
                     if #[cfg(any(feature = "l5"))] {
                         let cr1 = &self.regs.flt0cr1;
-                    } else if #[cfg(any(feature = "l4"))] {
+                    } else if #[cfg(feature = "l4")] {
                         let cr1 = &self.regs.dfsdm0_cr1;
                     } else {
-                        let cr1 = &self.regs.flt0.cr1;
+                        let cr1 = &self.regs.flt[0].cr1;
                     }
                 }
                 cr1.modify(|_, w| w.rswstart().set_bit())
@@ -893,10 +893,10 @@ where
                 cfg_if! {
                     if #[cfg(any(feature = "l5"))] {
                         let cr1 = &self.regs.flt1cr1;
-                    } else if #[cfg(any(feature = "l4"))] {
-                        // let cr1 = &regs.dfsdm1_cr1;
+                    } else if #[cfg(feature = "l4")] {
+                        let cr1 = &self.regs.dfsdm1_cr1;
                     } else {
-                        let cr1 = &self.regs.flt1.cr1;
+                        let cr1 = &self.regs.flt[1].cr1;
                     }
                 }
                 cr1.modify(|_, w| w.rswstart().set_bit())
@@ -905,10 +905,10 @@ where
                 cfg_if! {
                     if #[cfg(any(feature = "l5"))] {
                         let cr1 = &self.regs.flt2cr1;
-                    } else if #[cfg(any(feature = "l4"))] {
+                    } else if #[cfg(feature = "l4")] {
                         let cr1 = &self.regs.dfsdm2_cr1;
                     } else {
-                        let cr1 = &self.regs.flt2.cr1;
+                        let cr1 = &self.regs.flt[2].cr1;
                     }
                 }
                 cr1.modify(|_, w| w.rswstart().set_bit())
@@ -917,10 +917,10 @@ where
                 cfg_if! {
                     if #[cfg(any(feature = "l5"))] {
                         let cr1 = &self.regs.flt3cr1;
-                    } else if #[cfg(any(feature = "l4"))] {
+                    } else if #[cfg(feature = "l4")] {
                         let cr1 = &self.regs.dfsdm3_cr1;
                     } else {
-                        let cr1 = &self.regs.flt3.cr1;
+                        let cr1 = &self.regs.flt[3].cr1;
                     }
                 }
                 cr1.modify(|_, w| w.rswstart().set_bit())
@@ -950,10 +950,10 @@ where
                 cfg_if! {
                     if #[cfg(any(feature = "l5"))] {
                         let cr1 = &self.regs.flt0cr1;
-                    } else if #[cfg(any(feature = "l4"))] {
+                    } else if #[cfg(feature = "l4")] {
                         let cr1 = &self.regs.dfsdm0_cr1;
                     }else {
-                        let cr1 = &self.regs.flt0.cr1;
+                        let cr1 = &self.regs.flt[0].cr1;
                     }
                 }
                 cr1.modify(|_, w| w.jswstart().set_bit())
@@ -965,10 +965,10 @@ where
                 cfg_if! {
                     if #[cfg(any(feature = "l5"))] {
                         let cr1 = &self.regs.flt1cr1;
-                    } else if #[cfg(any(feature = "l4"))] {
-                        // let cr1 = &self.regs.dfsdm1_cr1;
+                    } else if #[cfg(feature = "l4")] {
+                        let cr1 = &self.regs.dfsdm1_cr1;
                     } else {
-                        let cr1 = &self.regs.flt1.cr1;
+                        let cr1 = &self.regs.flt[1].cr1;
                     }
                 }
                 cr1.modify(|_, w| w.jswstart().set_bit())
@@ -977,10 +977,10 @@ where
                 cfg_if! {
                     if #[cfg(any(feature = "l5"))] {
                         let cr1 = &self.regs.flt2cr1;
-                    } else if #[cfg(any(feature = "l4"))] {
+                    } else if #[cfg(feature = "l4")] {
                         let cr1 = &self.regs.dfsdm2_cr1;
                     } else {
-                        let cr1 = &self.regs.flt2.cr1;
+                        let cr1 = &self.regs.flt[2].cr1;
                     }
                 }
                 cr1.modify(|_, w| w.jswstart().set_bit())
@@ -989,10 +989,10 @@ where
                 cfg_if! {
                     if #[cfg(any(feature = "l5"))] {
                         let cr1 = &self.regs.flt3cr1;
-                    } else if #[cfg(any(feature = "l4"))] {
+                    } else if #[cfg(feature = "l4")] {
                         let cr1 = &self.regs.dfsdm3_cr1;
                     } else {
-                        let cr1 = &self.regs.flt3.cr1;
+                        let cr1 = &self.regs.flt[3].cr1;
                     }
                 }
                 cr1.modify(|_, w| w.jswstart().set_bit())
@@ -1046,10 +1046,10 @@ where
                 cfg_if! {
                     if #[cfg(any(feature = "l5"))] {
                         let rdatar = &self.regs.flt0rdatar;
-                    } else if #[cfg(any(feature = "l4"))] {
+                    } else if #[cfg(feature = "l4")] {
                         let rdatar = &self.regs.dfsdm0_rdatar;
                     } else {
-                        let rdatar = &self.regs.flt0.rdatar;
+                        let rdatar = &self.regs.flt[0].rdatar;
                     }
                 }
                 (rdatar.read().bits() as i32) >> 8
@@ -1061,10 +1061,10 @@ where
                 cfg_if! {
                     if #[cfg(any(feature = "l5"))] {
                         let rdatar = &self.regs.flt1rdatar;
-                    } else if #[cfg(any(feature = "l4"))] {
-                        // let rdatar = &self.regs.dfsdm1_rdatar;
+                    } else if #[cfg(feature = "l4")] {
+                        let rdatar = &self.regs.dfsdm1_rdatar;
                     } else {
-                        let rdatar = &self.regs.flt1.rdatar;
+                        let rdatar = &self.regs.flt[1].rdatar;
                     }
                 }
                 (rdatar.read().bits() as i32) >> 8
@@ -1073,10 +1073,10 @@ where
                 cfg_if! {
                     if #[cfg(any(feature = "l5"))] {
                         let rdatar = &self.regs.flt2rdatar;
-                    } else if #[cfg(any(feature = "l4"))] {
+                    } else if #[cfg(feature = "l4")] {
                         let rdatar = &self.regs.dfsdm2_rdatar;
                     } else {
-                        let rdatar = &self.regs.flt2.rdatar;
+                        let rdatar = &self.regs.flt[2].rdatar;
                     }
                 }
                 (rdatar.read().bits() as i32) >> 8
@@ -1085,10 +1085,10 @@ where
                 cfg_if! {
                     if #[cfg(any(feature = "l5"))] {
                         let rdatar = &self.regs.flt3rdatar;
-                    } else if #[cfg(any(feature = "l4"))] {
+                    } else if #[cfg(feature = "l4")] {
                         let rdatar = &self.regs.dfsdm3_rdatar;
                     } else {
-                        let rdatar = &self.regs.flt3.rdatar;
+                        let rdatar = &self.regs.flt[3].rdatar;
                     }
                 }
                 (rdatar.read().bits() as i32) >> 8
@@ -1104,10 +1104,10 @@ where
                 cfg_if! {
                     if #[cfg(any(feature = "l5"))] {
                         let jdatar = &self.regs.flt0jdatar;
-                    } else if #[cfg(any(feature = "l4"))] {
+                    } else if #[cfg(feature = "l4")] {
                         let jdatar = &self.regs.dfsdm0_jdatar;
                     } else {
-                        let jdatar = &self.regs.flt0.jdatar;
+                        let jdatar = &self.regs.flt[0].jdatar;
                     }
                 }
                 (jdatar.read().bits() as i32) >> 8
@@ -1119,10 +1119,10 @@ where
                 cfg_if! {
                     if #[cfg(any(feature = "l5"))] {
                         let jdatar = &self.regs.flt1jdatar;
-                    } else if #[cfg(any(feature = "l4"))] {
-                        // let jdatar = &self.regs.dfsdm1_jdatar;
+                    } else if #[cfg(feature = "l4")] {
+                        let jdatar = &self.regs.dfsdm1_jdatar;
                     } else {
-                        let jdatar = &self.regs.flt1.jdatar;
+                        let jdatar = &self.regs.flt[1].jdatar;
                     }
                 }
                 (jdatar.read().bits() as i32) >> 8
@@ -1131,10 +1131,10 @@ where
                 cfg_if! {
                     if #[cfg(any(feature = "l5"))] {
                         let jdatar = &self.regs.flt2jdatar;
-                    } else if #[cfg(any(feature = "l4"))] {
+                    } else if #[cfg(feature = "l4")] {
                         let jdatar = &self.regs.dfsdm2_jdatar;
                     } else {
-                        let jdatar = &self.regs.flt2.jdatar;
+                        let jdatar = &self.regs.flt[2].jdatar;
                     }
                 }
                 (jdatar.read().bits() as i32) >> 8
@@ -1143,10 +1143,10 @@ where
                 cfg_if! {
                     if #[cfg(any(feature = "l5"))] {
                         let jdatar = &self.regs.flt3jdatar;
-                    } else if #[cfg(any(feature = "l4"))] {
+                    } else if #[cfg(feature = "l4")] {
                         let jdatar = &self.regs.dfsdm3_jdatar;
                     } else {
-                        let jdatar = &self.regs.flt3.jdatar;
+                        let jdatar = &self.regs.flt[3].jdatar;
                     }
                 }
                 (jdatar.read().bits() as i32) >> 8
@@ -1203,10 +1203,10 @@ where
                 cfg_if! {
                     if #[cfg(any(feature = "l5"))] {
                         let cr1 = &self.regs.flt0cr1;
-                    } else if #[cfg(any(feature = "l4"))] {
+                    } else if #[cfg(feature = "l4")] {
                         let cr1 = &self.regs.dfsdm0_cr1;
                     } else {
-                        let cr1 = &self.regs.flt0.cr1;
+                        let cr1 = &self.regs.flt[0].cr1;
                     }
                 }
                 cr1.modify(|_, w| w.rdmaen().set_bit())
@@ -1218,10 +1218,10 @@ where
                 cfg_if! {
                     if #[cfg(any(feature = "l5"))] {
                         let cr1 = &self.regs.flt1cr1;
-                    } else if #[cfg(any(feature = "l4"))] {
-                        // let cr1 = &self.regs.dfsdm1_cr1;
+                    } else if #[cfg(feature = "l4")] {
+                        let cr1 = &self.regs.dfsdm1_cr1;
                     } else {
-                        let cr1 = &self.regs.flt1.cr1;
+                        let cr1 = &self.regs.flt[1].cr1;
                     }
                 }
                 cr1.modify(|_, w| w.rdmaen().set_bit())
@@ -1230,10 +1230,10 @@ where
                 cfg_if! {
                     if #[cfg(any(feature = "l5"))] {
                         let cr1 = &self.regs.flt2cr1;
-                    } else if #[cfg(any(feature = "l4"))] {
+                    } else if #[cfg(feature = "l4")] {
                         let cr1 = &self.regs.dfsdm2_cr1;
                     } else {
-                        let cr1 = &self.regs.flt2.cr1;
+                        let cr1 = &self.regs.flt[2].cr1;
                     }
                 }
                 cr1.modify(|_, w| w.rdmaen().set_bit())
@@ -1243,10 +1243,10 @@ where
                 cfg_if! {
                     if #[cfg(any(feature = "l5"))] {
                         let cr1 = &self.regs.flt3cr1;
-                    } else if #[cfg(any(feature = "l4"))] {
+                    } else if #[cfg(feature = "l4")] {
                         let cr1 = &self.regs.dfsdm3_cr1;
                     } else {
-                        let cr1 = &self.regs.flt3.cr1;
+                        let cr1 = &self.regs.flt[3].cr1;
                     }
                 }
                 cr1.modify(|_, w| w.rdmaen().set_bit())
@@ -1258,10 +1258,10 @@ where
                 cfg_if! {
                     if #[cfg(any(feature = "l5"))] {
                         let rdatar = &self.regs.flt0rdatar;
-                    } else if #[cfg(any(feature = "l4"))] {
+                    } else if #[cfg(feature = "l4")] {
                         let rdatar = &self.regs.dfsdm0_rdatar;
                     } else {
-                        let rdatar = &self.regs.flt0.rdatar;
+                        let rdatar = &self.regs.flt[0].rdatar;
                     }
                 }
                 &rdatar as *const _ as u32
@@ -1273,10 +1273,10 @@ where
                 cfg_if! {
                     if #[cfg(any(feature = "l5"))] {
                         let rdatar = &self.regs.flt1rdatar;
-                    } else if #[cfg(any(feature = "l4"))] {
-                        // let rdatar = &self.regs.dfsdm1_rdatar;
+                    } else if #[cfg(feature = "l4")] {
+                        let rdatar = &self.regs.dfsdm1_rdatar;
                     } else {
-                        let rdatar = &self.regs.flt1.rdatar;
+                        let rdatar = &self.regs.flt[1].rdatar;
                     }
                 }
                 &rdatar as *const _ as u32
@@ -1286,10 +1286,10 @@ where
                 cfg_if! {
                     if #[cfg(any(feature = "l5"))] {
                         let rdatar = &self.regs.flt2rdatar;
-                    } else if #[cfg(any(feature = "l4"))] {
+                    } else if #[cfg(feature = "l4")] {
                         let rdatar = &self.regs.dfsdm2_rdatar;
                     } else {
-                        let rdatar = &self.regs.flt2.rdatar;
+                        let rdatar = &self.regs.flt[2].rdatar;
                     }
                 }
                 &rdatar as *const _ as u32
@@ -1299,10 +1299,10 @@ where
                 cfg_if! {
                     if #[cfg(any(feature = "l5"))] {
                         let rdatar = &self.regs.flt3rdatar;
-                    } else if #[cfg(any(feature = "l4"))] {
+                    } else if #[cfg(feature = "l4")] {
                         let rdatar = &self.regs.dfsdm3_rdatar;
                     } else {
-                        let rdatar = &self.regs.flt3.rdatar;
+                        let rdatar = &self.regs.flt[3].rdatar;
                     }
                 }
                 &rdatar as *const _ as u32
@@ -1340,10 +1340,10 @@ where
                 cfg_if! {
                     if #[cfg(any(feature = "l5"))] {
                         let cr2 = &self.regs.flt0cr2;
-                    } else if #[cfg(any(feature = "l4"))] {
+                    } else if #[cfg(feature = "l4")] {
                         let cr2 = &self.regs.dfsdm0_cr2;
                     } else {
-                        let cr2 = &self.regs.flt0.cr2;
+                        let cr2 = &self.regs.flt[0].cr2;
                     }
                 }
 
@@ -1364,10 +1364,10 @@ where
                 cfg_if! {
                     if #[cfg(any(feature = "l5"))] {
                         let cr2 = &self.regs.flt1cr2;
-                    } else if #[cfg(any(feature = "l4"))] {
-                        // let cr2 = &self.regs.dfsdm1_cr2;
+                    } else if #[cfg(feature = "l4")] {
+                        let cr2 = &self.regs.dfsdm1_cr2;
                     } else {
-                        let cr2 = &self.regs.flt1.cr2;
+                        let cr2 = &self.regs.flt[1].cr2;
                     }
                 }
                 cr2.modify(|_, w| match interrupt_type {
@@ -1384,10 +1384,10 @@ where
                 cfg_if! {
                     if #[cfg(any(feature = "l5"))] {
                         let cr2 = &self.regs.flt1cr2;
-                    } else if #[cfg(any(feature = "l4"))] {
+                    } else if #[cfg(feature = "l4")] {
                         let cr2 = &self.regs.dfsdm2_cr2;
                     } else {
-                        let cr2 = &self.regs.flt2.cr2;
+                        let cr2 = &self.regs.flt[2].cr2;
                     }
                 }
 
@@ -1405,10 +1405,10 @@ where
                 cfg_if! {
                     if #[cfg(any(feature = "l5"))] {
                         let cr2 = &self.regs.flt3cr2;
-                    } else if #[cfg(any(feature = "l4"))] {
+                    } else if #[cfg(feature = "l4")] {
                         let cr2 = &self.regs.dfsdm3_cr2;
                     } else {
-                        let cr2 = &self.regs.flt3.cr2;
+                        let cr2 = &self.regs.flt[3].cr2;
                     }
                 }
 

--- a/src/dma.rs
+++ b/src/dma.rs
@@ -24,7 +24,7 @@ cfg_if! {
     }
 }
 
-#[cfg(any(feature = "g0", feature = "g4", feature = "wl"))]
+#[cfg(any(feature = "g0", feature = "g4", feature = "wl", feature = "l4plus"))]
 use pac::DMAMUX;
 
 // todo: DMAMUX2 support (Not sure if WB has it, but H7 has both).
@@ -49,7 +49,101 @@ pub enum DmaPeriph {
 
 #[derive(Copy, Clone)]
 #[repr(usize)]
-#[cfg(not(feature = "h7"))]
+#[cfg(feature = "l4p5")]
+pub enum DmaInput {
+    Adc1 = 5,
+    Adc2 = 6,
+    Dac1Ch1 = 7,
+    Dac1Ch2 = 8,
+    Tim6Up = 9,
+    Tim7Up = 10,
+    Spi1Rx = 11,
+    Spi1Tx = 12,
+    Spi2Rx = 13,
+    Spi2Tx = 14,
+    Spi3Rx = 15,
+    Spi3Tx = 16,
+    I2c1Rx = 17,
+    I2c1Tx = 18,
+    I2c2Rx = 19,
+    I2c2Tx = 20,
+    I2c3Rx = 21,
+    I2c3Tx = 22,
+    I2c4Rx = 23,
+    I2c4Tx = 24,
+    Usart1Rx = 25,
+    Usart1Tx = 26,
+    Usart2Rx = 27,
+    Usart2Tx = 28,
+    Usart3Rx = 29,
+    Usart3Tx = 30,
+    Uart4Rx = 31,
+    Uart4Tx = 32,
+    Uart5Rx = 33,
+    Uart5Tx = 34,
+    Lpuart1Rx = 35,
+    Lpuart1Tx = 36,
+    Sai1A = 37,
+    Sai1B = 38,
+    Sai2A = 39,
+    Sai2B = 40,
+    Octospi1 = 41,
+    Octospi2 = 42,
+    Tim1Ch1 = 43,
+    Tim1Ch2 = 44,
+    Tim1Ch3 = 45,
+    Tim1Ch4 = 46,
+    Tim1Up = 47,
+    Tim1Trig = 48,
+    Tim1Com = 49,
+    Tim8Ch1 = 50,
+    Tim8Ch2 = 51,
+    Tim8Ch3 = 52,
+    Tim8Ch4 = 53,
+    Tim8Up = 54,
+    Tim8Trig = 55,
+    Tim8Com = 56,
+    Tim2Ch1 = 57,
+    Tim2Ch2 = 58,
+    Tim2Ch3 = 59,
+    Tim2Ch4 = 60,
+    Tim2Up = 61,
+    Tim3Ch1 = 62,
+    Tim3Ch2 = 63,
+    Tim3Ch3 = 64,
+    Tim3Ch4 = 65,
+    Tim3Up = 66,
+    Tim3Trig = 67,
+    Tim4Ch1 = 68,
+    Tim4Ch2 = 69,
+    Tim4Ch3 = 70,
+    Tim4Ch4 = 71,
+    Tim4Up = 72,
+    Tim5Ch1 = 73,
+    Tim5Ch2 = 74,
+    Tim5Ch3 = 75,
+    Tim5Ch4 = 76,
+    Tim5Up = 77,
+    Tim5Trig = 78,
+    Tim15Ch1 = 79,
+    Tim15Up = 80,
+    Tim15Trig = 81,
+    Tim15Com = 82,
+    Tim16Ch1 = 83,
+    Tim16Up = 84,
+    Tim17Ch1 = 85,
+    Tim17Up = 86,
+    Dfsdm1F0 = 87,
+    Dfsdm1F1 = 88,
+    DcmiPssi = 91,
+    AesIn = 92,
+    AesOut = 93,
+    HashIn = 94,
+}
+
+#[derive(Copy, Clone)]
+#[repr(usize)]
+#[cfg(all(not(feature = "h7"), not(feature = "l4p5")))]
 /// A list of DMA input sources. The integer values represent their DMAMUX register value, on
 /// MCUs that use this. G4 RM, Table 91: DMAMUX: Assignment of multiplexer inputs to resources.
 pub enum DmaInput {
@@ -243,7 +337,7 @@ pub enum DmaInput2 {
 }
 
 impl DmaInput {
-    #[cfg(any(feature = "f3", feature = "l4"))]
+    #[cfg(all(any(feature = "f3", feature = "l4"), not(feature = "l4plus")))]
     /// Select the hard set channel associated with a given input source. See L44 RM, Table 41.
     pub fn dma1_channel(&self) -> DmaChannel {
         match self {
@@ -293,7 +387,7 @@ impl DmaInput {
         }
     }
 
-    #[cfg(feature = "l4")]
+    #[cfg(all(feature = "l4", not(feature = "l4plus")))]
     /// Find the value to set in the DMA_CSELR register, for L4. Ie, channel select value for a given DMA input.
     /// See L44 RM, Table 41.
     pub fn dma1_channel_select(&self) -> u8 {
@@ -1277,7 +1371,7 @@ pub struct Dma<D> {
                 }
             }
 
-            #[cfg(feature = "l4")] // Only required on L4
+            #[cfg(all(feature = "l4", not(feature = "l4plus")))] // Only required on L4
             /// Select which peripheral on a given channel we're using.
             /// See L44 RM, Table 41.
             pub fn channel_select(&mut self, input: DmaInput) {
@@ -1608,6 +1702,7 @@ pub struct Dma<D> {
     feature = "h7",
     feature = "wb",
     feature = "wl",
+    feature = "l4plus"
 ))]
 /// Configure a specific DMA channel to work with a specific peripheral.
 pub fn mux(periph: DmaPeriph, channel: DmaChannel, input: DmaInput) {

--- a/src/flash/non_trustzone.rs
+++ b/src/flash/non_trustzone.rs
@@ -312,7 +312,7 @@ impl Flash {
 
         // 4. Set the STRT bit in the FLASH_CR register.
         cfg_if! {
-            if #[cfg(not(any(feature = "l4", feature = "h7")))] {
+            if #[cfg(not(any(feature = "l4", feature = "l4p", feature = "h7")))] {
                 regs.cr.modify(|_, w| w.strt().set_bit());
             } else {
                 regs.cr.modify(|_, w| w.start().set_bit());
@@ -446,7 +446,7 @@ impl Flash {
                 // wait until the QW1/2 bit is cleared in the corresponding FLASH_SR1/2 register.
                 regs.cr.modify(|_, w| w.start().set_bit());
                 while regs.sr.read().qw().bit_is_set() {}
-            } else if #[cfg(feature = "l4")] {
+            } else if #[cfg(any(feature = "l4", feature = "l4p"))] {
                 regs.cr.modify( | _, w | w.start().set_bit());
             } else {
                 regs.cr.modify(|_, w| w.strt().set_bit());
@@ -460,7 +460,7 @@ impl Flash {
         cfg_if! {
             if #[cfg(feature = "h7")] {
                 regs.cr.modify(|_, w| w.ber().clear_bit());
-            } else if #[cfg(any(feature = "l4", feature = "g4"))] {
+            } else if #[cfg(any(feature = "l4", feature = "l4p", feature = "g4"))] {
                 regs.cr.modify(|_, w| w.mer1().clear_bit());
             } else {
                 regs.cr.modify(|_, w| w.mer().clear_bit());

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -1161,7 +1161,7 @@ pub fn clear_exti_interrupt(line: u8) {
                         _ => panic!(),
                     }
                 });
-            } else if #[cfg(any(feature = "f3", feature = "l4"))] {
+            } else if #[cfg(any(feature = "f3", feature = "l4", feature = "l4p"))] {
                 (*EXTI::ptr()).pr1.modify(|_, w| {
                     match line {
                         0 => w.pr0().set_bit(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -152,6 +152,7 @@
     feature = "l4x3",
     feature = "l4x5",
     feature = "l4x6",
+    feature = "l4p5",
     feature = "l552",
     feature = "l562",
     feature = "g030",
@@ -258,6 +259,9 @@ pub use stm32l4::stm32l4x5 as pac;
 
 #[cfg(feature = "l4x6")]
 pub use stm32l4::stm32l4x6 as pac;
+
+#[cfg(feature = "l4p5")]
+pub use stm32l4::stm32l4p5 as pac;
 
 // L5 PAC
 #[cfg(feature = "l552")]

--- a/src/low_power.rs
+++ b/src/low_power.rs
@@ -191,7 +191,7 @@ cfg_if! {
             // – WUFx bits are cleared in power status register 1 (PWR_SR1)
             // (Clear by setting cwfuf bits in `pwr_scr`.)
             cfg_if! {
-                if #[cfg(feature = "l4")] {
+                if #[cfg(all(feature = "l4", not(feature = "l4plus")))] {
                     pwr.scr.write(|w| {
                         w.wuf1().set_bit();
                         w.wuf2().set_bit();

--- a/src/rtc.rs
+++ b/src/rtc.rs
@@ -137,7 +137,7 @@ impl Rtc {
                     pwr.cr.read(); // read to allow the pwr clock to enable
                     pwr.cr.modify(|_, w| w.dbp().set_bit());
                     while pwr.cr.read().dbp().bit_is_clear() {}
-                } else if #[cfg(any(feature = "l4", feature = "l5", feature = "g4", feature = "l412", feature = "wb", feature = "wl"))] {
+                } else if #[cfg(any(feature = "l4", feature = "l4p", feature = "l5", feature = "g4", feature = "l412", feature = "wb", feature = "wl"))] {
                     // 1. Enable the power interface clock by setting the PWREN bits in the Section 6.4.18:
                     // APB1 peripheral clock enable register 1 (RCC_APB1ENR1)
                     #[cfg(not(any(feature = "wb", feature = "wl")))]
@@ -390,7 +390,7 @@ impl Rtc {
         let exti = unsafe { &(*EXTI::ptr()) };
 
         cfg_if! {
-            if #[cfg(any(feature = "f3", feature = "l4"))] {
+            if #[cfg(any(feature = "f3", feature = "l4", feature = "l4p"))] {
                 exti.imr1.modify(|_, w| w.mr20().unmasked());
                 exti.rtsr1.modify(|_, w| w.tr20().set_bit());
                 exti.ftsr1.modify(|_, w| w.tr20().clear_bit());
@@ -429,7 +429,7 @@ impl Rtc {
         // Ensure access to Wakeup auto-reload counter and bits WUCKSEL[2:0] is allowed.
         // Poll WUTWF until it is set in RTC_ISR (RTC2)/RTC_ICSR (RTC3) (May not be avail on F3)
         cfg_if! {
-            if #[cfg(any(feature = "l5", feature = "g0", feature = "g4", feature = "l412", feature = "wl"))] {
+            if #[cfg(any(feature = "l5", feature = "g0", feature = "g4", feature = "l412", feature = "wl", feature = "l4p"))] {
                 while self.regs.icsr.read().wutwf().bit_is_clear() {}
             } else {
                 while self.regs.isr.read().wutwf().bit_is_clear() {}
@@ -445,7 +445,7 @@ impl Rtc {
         self.regs.cr.modify(|_, w| w.wutie().set_bit());
 
         cfg_if! {
-            if #[cfg(any(feature = "l412", feature = "l5", feature = "g0", feature = "g4", feature = "l412", feature = "wl"))] {
+            if #[cfg(any(feature = "l412", feature = "l5", feature = "g0", feature = "g4", feature = "l412", feature = "wl", feature = "l4p"))] {
                 self.regs.scr.write(|w| w.cwutf().set_bit());
             } else {
                 self.regs.isr.modify(|_, w| w.wutf().clear_bit());
@@ -492,7 +492,7 @@ impl Rtc {
         }
 
         cfg_if! {
-            if #[cfg(any(feature = "l5", feature = "g0", feature = "g4", feature = "l412", feature = "wl"))] {
+            if #[cfg(any(feature = "l5", feature = "g0", feature = "g4", feature = "l412", feature = "wl", feature = "l4p"))] {
                 while self.regs.icsr.read().wutwf().bit_is_clear() {}
             } else {
                 while self.regs.isr.read().wutwf().bit_is_clear() {}
@@ -515,7 +515,7 @@ impl Rtc {
             regs.cr.modify(|_, w| w.wute().clear_bit());
 
             cfg_if! {
-                if #[cfg(any(feature = "l412", feature = "l5", feature = "g0", feature = "g4", feature = "l412", feature = "wl"))] {
+                if #[cfg(any(feature = "l412", feature = "l5", feature = "g0", feature = "g4", feature = "l412", feature = "wl", feature = "l4p"))] {
                     regs.scr.write(|w| w.cwutf().set_bit());
                 } else {
                     // Note that we clear this by writing 0, which isn't
@@ -544,7 +544,7 @@ impl Rtc {
         // todo: L4 has ICSR and ISR regs. Maybe both for backwards compat?
 
         cfg_if! {
-             if #[cfg(any(feature = "l5", feature = "g0", feature = "g4", feature = "l412", feature = "wl"))] {
+             if #[cfg(any(feature = "l5", feature = "g0", feature = "g4", feature = "l412", feature = "wl", feature = "l4p"))] {
                  // Enter init mode if required. This is generally used to edit the clock or calendar,
                  // but not for initial enabling steps.
                  if init_mode && self.regs.icsr.read().initf().bit_is_clear() {

--- a/src/sai.rs
+++ b/src/sai.rs
@@ -14,9 +14,11 @@ use crate::pac::sai4 as sai;
 
 #[cfg(feature = "g0")]
 use crate::pac::dma as dma_p;
+
 #[cfg(any(
     feature = "f3",
     feature = "l4",
+    feature = "l4p",
     feature = "l5",
     feature = "g4",
     feature = "h7",
@@ -621,7 +623,7 @@ where
             // The NOMCK bit of the SAI_xCR1 register is used to define whether the master clock is
             // generated or not.
             // Inversed polarity on non-H7 based on how we have `MasterClock` enabled.
-            #[cfg(not(any(feature = "h7", feature = "l4", feature = "l5")))]
+            #[cfg(not(any(feature = "h7", feature = "l4", feature = "l4p", feature = "l5")))]
             w.mcken().bit(config_a.master_clock as u8 == 0);
             #[cfg(feature = "h7")]
             // Due to an H743v PAC error, xCR bit 19 is called NODIV (Which is how it is on other platforms).
@@ -678,7 +680,7 @@ where
             w.mono().bit(config_b.mono as u8 != 0);
             w.syncen().bits(config_b.sync as u8);
             w.ckstr().bit(config_b.clock_strobe as u8 != 0);
-            #[cfg(not(any(feature = "h7", feature = "l4", feature = "l5")))]
+            #[cfg(not(any(feature = "h7", feature = "l4", feature = "l4p", feature = "l5")))]
             w.mcken().bit(config_b.master_clock as u8 == 0);
             #[cfg(feature = "h7")]
             w.nodiv().bit(config_b.master_clock as u8 != 0);
@@ -814,7 +816,7 @@ where
         // 1. Configure SAI_A in TDM master mode (see Table 422).
         // (Above. Although we don't check this)
         // 2. Configure the PDM interface as follows:
-        #[cfg(not(feature = "l4"))]
+        #[cfg(not(any(feature = "l4", feature = "l4p")))]
         if config_a.pdm_mode {
             assert!(config_a.pdm_clock_used <= 4 && config_a.pdm_clock_used >= 1);
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -54,7 +54,7 @@ macro_rules! rcc_en_reset {
                 $rcc.apb1enr.modify(|_, w| w.[<$periph en>]().set_bit());
                 $rcc.apb1rstr.modify(|_, w| w.[<$periph rst>]().set_bit());
                 $rcc.apb1rstr.modify(|_, w| w.[<$periph rst>]().clear_bit());
-            } else if #[cfg(any(feature = "l4", feature = "l5", feature = "g4", feature = "wb", feature = "wl"))] {
+            } else if #[cfg(any(feature = "l4", feature = "l5", feature = "l4p", feature = "g4", feature = "wb", feature = "wl"))] {
                 $rcc.apb1enr1.modify(|_, w| w.[<$periph en>]().set_bit());
                 $rcc.apb1rstr1.modify(|_, w| w.[<$periph rst>]().set_bit());
                 $rcc.apb1rstr1.modify(|_, w| w.[<$periph rst>]().clear_bit());


### PR DESCRIPTION
Currently draft - not tested but compiles on local stm32-rs version.

@David-OConnor appreciate any comments/reviews if stuff should be done differently.

On the Octo / Quad SPI: Would it make sense to have a separate module for Octo - compared to the Quad SPI.
There are a lot of functionality that seems to be missing on Quad SPI that is available on Octo SPI.