### PR TITLE
Add implementation of CountDown for timer

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,8 @@ edition = "2021"
 
 [dependencies]
 cortex-m = "0.7.6"
+void = { version = "1.0.2", default-features = false }
+embedded-time = "0.12.1"
 
 # Peripheral Access Crates
 stm32f3 = { version = "0.15.1", optional = true }

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -17,6 +17,12 @@ use core;
 
 #[cfg(feature = "embedded-hal")]
 use embedded_hal::blocking::delay::{DelayMs, DelayUs};
+use embedded_time::rate::Hertz;
+use embedded_time::duration;
+use embedded_hal::timer::CountDown;
+
+
+use void::Void;
 
 use num_traits::float::FloatCore; // To round
 
@@ -949,6 +955,71 @@ macro_rules! make_timer {
         impl DelayUs<u8> for Timer<pac::$TIMX> {
             fn delay_us(&mut self, us: u8) {
                 self.delay_us(us as u32);
+            }
+        }
+
+        /// Implementation of CountDown for timer
+        /// To use Countdown it is prefered to configure new timer in Oneshot mode :
+        ///
+        ///     Example :
+        ///     llet tim16_conf = TimerConfig {
+        //             one_pulse_mode: true,
+        //             ..Default::default()
+        //         };
+        ///
+        ///     Creation of timer. Here the freq arg value is not important, the freq
+        ///         will be changed for each CountDown start timer depends on delay wanted.
+        ///
+        /// let mut tim16: Timer<TIM16> = Timer::new_tim16(dp.TIM16, 1000., tim16_conf, &clocks);
+        ///
+        ///
+        #[cfg(feature = "embedded-hal")]
+        impl CountDown for Timer<pac::$TIMX>
+        {
+            type Time = duration::Generic<u32>;
+
+            fn start<T>(&mut self, timeout: T)
+                where
+                    T: Into<Self::Time>,
+            {
+
+                //Disable timer and clear flag uif
+                self.disable();
+                self.clear_uif();
+
+                //Get timeout
+                let timeout: Self::Time = timeout.into();
+
+                let denom = timeout.scaling_factor().denominator();
+
+                //Prevent a division by zero
+                if *denom != 0 {
+                    //Convert time to seconds
+                    let time_to_s = timeout.integer() as f32 / *denom as f32;
+
+                    //Configure timer
+                    self.set_freq(1. / (time_to_s)).ok();
+                    self.reset_count();
+                    //Update event to setup prescale and reload registers
+                    self.reinitialize();
+                    self.clear_uif();
+
+                    //start the timer
+                    self.enable();
+                }
+
+            }
+
+            /// Wait until the timer has elapsed
+            /// and than clear the event.
+            fn wait(&mut self) -> nb::Result<(), Void> {
+                if !self.get_uif() {
+                    Err(nb::Error::WouldBlock)
+                } else {
+                    self.clear_uif();
+                    self.disable();
+                    Ok(())
+                }
             }
         }
     }


### PR DESCRIPTION
Hello, 

In order to use an existing driver that uses a CountDown timer, I needed CountDown trait implementation for timer.
I tried to add this functionality into crate. I only checked with stm32wb55 , it will be interesting to test on others MCU.
I don’t know if is it an acceptable add, but I added a dependency to embedded-time  in the Cargo.toml. May be it is necessary to make conditional the embedded-time dependency. 