### PR TITLE
[modif] RTC : Adapt get_year() according to set_date and set_year function with 2000 year offset

### DIFF
--- a/src/rtc.rs
+++ b/src/rtc.rs
@@ -828,7 +828,7 @@ impl Rtc {
     /// Get the year component of the current date.
     pub fn get_year(&mut self) -> u16 {
         let dr = self.regs.dr.read();
-        bcd2_decode(dr.yt().bits(), dr.yu().bits()) as u16
+        (bcd2_decode(dr.yt().bits(), dr.yu().bits()) + 2000) as u16
     }
 
     /// Get the current date.


### PR DESCRIPTION
 I don't know why there is not millennium bit into RTC, maybe ST doesn't allow used MCU with date before year 2000.
 Into function set_year and set_date Year is decremented by 2000, but not incremented by 2000 into get_year.
 Offset of 2000 year is added in get_date to obtain timestamp expected