### PR TITLE
Enabled PWR peripheral when setting the iosv bit. Needed for stm32l4x…

### DIFF
--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -729,6 +729,7 @@ impl Pin {
                                 {
                                     let pwr = unsafe { &(*pac::PWR::ptr()) };
                                     // RM0351: Setting this bit (IOSV) is mandatory to use PG[15:2].
+                                    rcc.apb1enr1.modify(|_, w| w.pwren().set_bit());
                                     pwr.cr2.modify(|_, w| w.iosv().set_bit());
                                 }
                             }


### PR DESCRIPTION
Closes https://github.com/David-OConnor/stm32-hal/issues/79
Enabled PWR peripheral when setting the iosv bit. Needed for stm32l46 when working
with GPIOG.