### PR TITLE
COMP updates. Added Port::I to H747

### DIFF
--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -190,7 +190,8 @@ pub enum Port {
     H,
     #[cfg(any(
         feature = "h747cm4",
-        feature = "h747cm7"
+        feature = "h747cm7",
+        feature = "l4x6",
     ))]
     I,
 }
@@ -260,7 +261,8 @@ impl Port {
             Self::H => 7,
             #[cfg(any(
                 feature = "h747cm4",
-                feature = "h747cm7"
+                feature = "h747cm7",
+                feature = "l4x6",
             ))]
             Self::I => 8,
         }
@@ -812,16 +814,23 @@ impl Pin {
                     }
                 }
                 #[cfg(any(
+                    feature = "l4x6",
                     feature = "h747cm4",
                     feature = "h747cm7"
                 ))]
                 Port::I => {
                     cfg_if! {
                         if #[cfg(feature = "h7")] {
-                            if rcc.ahb4enr.read().gpiohen().bit_is_clear() {
+                            if rcc.ahb4enr.read().gpioien().bit_is_clear() {
                                 rcc.ahb4enr.modify(|_, w| w.gpioien().set_bit());
                                 rcc.ahb4rstr.modify(|_, w| w.gpioirst().set_bit());
                                 rcc.ahb4rstr.modify(|_, w| w.gpioirst().clear_bit());
+                            }
+                        } else if #[cfg(feature = "l4")] {
+                            if rcc.ahb2enr.read().gpioien().bit_is_clear() {
+                                rcc.ahb2enr.modify(|_,w| w.gpioien().set_bit());
+                                rcc.ahb2rstr.modify(|_, w| w.gpioirst().set_bit());
+                                rcc.ahb2rstr.modify(|_, w| w.gpioirst().clear_bit());
                             }
                         }
                     }
@@ -1388,7 +1397,8 @@ const fn regs(port: Port) -> *const pac::gpioa::RegisterBlock {
         Port::H => crate::pac::GPIOH::ptr() as _,
         #[cfg(any(
             feature = "h747cm4",
-            feature = "h747cm7"
+            feature = "h747cm7",
+            feature = "l4x6"
         ))]
         Port::I => crate::pac::GPIOI::ptr() as _,
     }

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -188,6 +188,11 @@ pub enum Port {
         feature = "wl"
     )))]
     H,
+    #[cfg(any(
+        feature = "h747cm4",
+        feature = "h747cm7"
+    ))]
+    I,
 }
 
 impl Port {
@@ -253,6 +258,11 @@ impl Port {
                 feature = "wl"
             )))]
             Self::H => 7,
+            #[cfg(any(
+                feature = "h747cm4",
+                feature = "h747cm7"
+            ))]
+            Self::I => 8,
         }
     }
 }
@@ -797,6 +807,21 @@ impl Pin {
                         } else { // L4, L5, G4
                             if rcc.ahb2enr.read().gpiohen().bit_is_clear() {
                                 rcc_en_reset!(ahb2, gpioh, rcc);
+                            }
+                        }
+                    }
+                }
+                #[cfg(any(
+                    feature = "h747cm4",
+                    feature = "h747cm7"
+                ))]
+                Port::I => {
+                    cfg_if! {
+                        if #[cfg(feature = "h7")] {
+                            if rcc.ahb4enr.read().gpiohen().bit_is_clear() {
+                                rcc.ahb4enr.modify(|_, w| w.gpioien().set_bit());
+                                rcc.ahb4rstr.modify(|_, w| w.gpioirst().set_bit());
+                                rcc.ahb4rstr.modify(|_, w| w.gpioirst().clear_bit());
                             }
                         }
                     }
@@ -1361,6 +1386,11 @@ const fn regs(port: Port) -> *const pac::gpioa::RegisterBlock {
             feature = "wl"
         )))]
         Port::H => crate::pac::GPIOH::ptr() as _,
+        #[cfg(any(
+            feature = "h747cm4",
+            feature = "h747cm7"
+        ))]
+        Port::I => crate::pac::GPIOI::ptr() as _,
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -537,7 +537,8 @@ pub mod usart;
 
 #[cfg(any(
     feature = "l4",
-    feature = "g4"
+    feature = "g4",
+    feature = "h7"
 ))]
 pub mod comp;
 


### PR DESCRIPTION
This enables COMP on H7 and L4.

Tested on `H747I-DISCO` and `L496G-DISCO` boards.

Also added `Port::I` on the H747, as the LEDs are mapped to PIx on the disco board.