### PR TITLE
CAN read_status() support for fdCAN and bxCAN

### DIFF
--- a/src/can.rs
+++ b/src/can.rs
@@ -62,7 +62,13 @@ impl Can {
 
     /// Print the (raw) contents of the status register.
     pub fn read_status(&self) -> u32 {
-        unsafe { self.regs.psr.read().bits() }
+        cfg_if! {
+            if #[cfg(any(feature = "h7", feature = "l5", feature = "g4"))] {
+                unsafe { self.regs.psr.read().bits() }
+            } else {
+                unsafe { self.regs.msr.read().bits() }
+            }
+        }
     }
 }
 


### PR DESCRIPTION
Here just a quick idea for a fix for my issue #97

the bxCAN hardware uses a different status register
maybe its just as easy as to check for the feature and use MSR instead.

bxCAN has the following status registers.
[msr](https://docs.rs/stm32l4/0.15.1/stm32l4/stm32l4x1/can1/msr/index.html) master status register


just tested it with my L431. Where I did build a 4.7Kb custom CAN-Bootloader.