### PR TITLE
Make RccPeriph, BaudPeriph public

### DIFF
--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -358,7 +358,12 @@ where
 
         result
     }
+}
 
+impl<R> I2c<R>
+where
+    R: Deref<Target = pac::i2c1::RegisterBlock>,
+{
     /// Enable SMBus support. See L44 RM, section 37.4.11: SMBus initialization
     pub fn enable_smbus(&mut self) -> Result<(), Error> {
         // todo: Roll this into an init setting or I2cConfig struct etc.
@@ -724,17 +729,14 @@ impl i2c::Error for Error {
 }
 
 #[cfg(feature = "embedded_hal")]
-impl<R> i2c::ErrorType for I2c<R>
-where
-    R: Deref<Target = pac::i2c1::RegisterBlock> + RccPeriph,
-{
+impl<R> i2c::ErrorType for I2c<R> {
     type Error = Error;
 }
 
 #[cfg(feature = "embedded_hal")]
 impl<R> i2c::I2c for I2c<R>
 where
-    R: Deref<Target = pac::i2c1::RegisterBlock> + RccPeriph,
+    R: Deref<Target = pac::i2c1::RegisterBlock>,
 {
     fn transaction(
         &mut self,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -517,6 +517,7 @@ cfg_if! {
 // For use with timers; converting ticks to real time.
 pub mod instant;
 mod util;
+pub use util::{BaudPeriph, RccPeriph};
 
 // todo: should these helper macros be removed from this library? It has nothing to do with STM32.
 


### PR DESCRIPTION
These traits are necessary for handling peripherals in a generic way since many of the relevant methods are gated by them.