### PR TITLE
F4 - Implement PLLQ on Clocks, Enable BaudPeriph and RccPeriph for UART4 and UART6, and fix build errors with embedded_hal feature

### DIFF
--- a/src/clocks/f.rs
+++ b/src/clocks/f.rs
@@ -505,7 +505,9 @@ impl Clocks {
                         w.pllsrc().bit(pll_src.bits() != 0);
                         w.plln().bits(self.plln);
                         w.pllm().bits(self.pllm);
-                        w.pllp().bits(self.pllp as u8)
+                        w.pllp().bits(self.pllp as u8);
+                        w.pllq().bits(self.pllq.value());
+                        w
                     });
                 }
             }
@@ -645,7 +647,16 @@ impl Clocks {
         #[cfg(feature = "f3")]
         return self.sysclk() / self.usb_pre.value() as u32;
         #[cfg(feature = "f4")]
-        return 0; // todo
+        match self.input_src {
+            InputSrc::Pll(pll_src) => {
+                let input_freq = match pll_src {
+                    PllSrc::Hsi => 16_000_000,
+                    PllSrc::Hse(freq) => freq,
+                };
+                input_freq / self.pllm as u32 * self.plln as u32 / self.pllq.value() as u32
+            }
+            _ => 0
+        }
     }
 
     pub fn apb1(&self) -> u32 {

--- a/src/util.rs
+++ b/src/util.rs
@@ -169,7 +169,7 @@ impl BaudPeriph for pac::USART3 {
 }
 
 cfg_if! {
-    if #[cfg(any(feature = "l4x6", feature = "h7"))] {
+    if #[cfg(any(feature = "l4x6", feature = "h7", feature = "f401", feature = "f407"))] {
         impl BaudPeriph for pac::UART4 {
             fn baud(clock_cfg: &Clocks) -> u32 {
                 clock_cfg.apb1()
@@ -182,7 +182,7 @@ cfg_if! {
             }
         }
 
-        #[cfg(any(feature = "h7", feature = "f401"))]
+        #[cfg(any(feature = "h7", feature = "f401", feature = "f407"))]
         impl BaudPeriph for pac::USART6 {
             fn baud(clock_cfg: &Clocks) -> u32 {
                 clock_cfg.apb2()
@@ -791,7 +791,7 @@ impl RccPeriph for pac::USART3 {
 }
 
 cfg_if! {
-    if #[cfg(any(feature = "l4x6", feature = "g473", feature = "g474", feature = "g483", feature = "g484", feature = "h7"))] {
+    if #[cfg(any(feature = "l4x6", feature = "g473", feature = "g474", feature = "g483", feature = "g484", feature = "h7", feature = "f401", feature = "f407"))] {
         impl RccPeriph for pac::UART4 {
             fn en_reset(rcc: &RegisterBlock) {
                 rcc_en_reset!(apb1, uart4, rcc);
@@ -844,7 +844,7 @@ cfg_if! {
             }
         }
 
-        #[cfg(any(feature = "h7", feature = "f401"))]
+        #[cfg(any(feature = "h7", feature = "f401", feature = "f407"))]
         impl RccPeriph for pac::USART6 {
             fn en_reset(rcc: &RegisterBlock) {
                 rcc_en_reset!(apb2, usart6, rcc);


### PR DESCRIPTION
- Fix PLLQ not being set on the F4 platform preventing USB from working
- Implement Clocks::usb() for the F4 platform
- Correct UART4 and UART6 on the F4 platform not having BaudPeriph or RccPeriph, preventing use
- Draft implementation of embedded_hal::I2c for F4

I have tested and verified that PLLQ is working properly (allowing USB to function), that the Clocks::usb() returns the correct frequency, and that UART4 and UART6 operate as intended.

I have modified the code in i2c_f4.rs to compile, implementing a rough transaction() function that essentially does what the previous read and write functions do. There is an 'Operation Contract' for transaction() that we aren't following - specifically we don't meet 'Data from adjacent operations of the same type are sent after each other without an SP or SR'.

Given how this code has been broken for a while and nobody has complained, I don't think it's a high priority to refactor this function and have the state machine necessary to meet this condition. I only use embedded_hal::digital::OutputPin, so I just need this to compile for my use-case.