### PR TITLE
Bound while loops and consolidate errors

### DIFF
--- a/src/clocks/baseline.rs
+++ b/src/clocks/baseline.rs
@@ -952,19 +952,19 @@ impl Clocks {
             InputSrc::Lsi => {
                 rcc.csr2().modify(|_, w| w.lsion().bit(true));
 
-                i = 0;
-                while rcc.csr2().read().lsirdy().bit_is_clear() {
-                    wait_hang!(i);
-                }
+                bounded_loop!(
+                    rcc.csr2().read().lsirdy().bit_is_clear(),
+                    Error::RegisterUnchanged
+                );
             }
             #[cfg(feature = "c0")]
             InputSrc::Lse => {
                 rcc.csr1().modify(|_, w| w.lseon().bit(true));
 
-                i = 0;
-                while rcc.csr1().read().lserdy().bit_is_clear() {
-                    wait_hang!(i);
-                }
+                bounded_loop!(
+                    rcc.csr1().read().lserdy().bit_is_clear(),
+                    Error::RegisterUnchanged
+                );
             }
             #[cfg(feature = "c071")]
             InputSrc::HsiUsb48 => {
@@ -1362,10 +1362,10 @@ impl Clocks {
             #[cfg(feature = "c0")]
             InputSrc::Lsi => {
                 rcc.csr2().modify(|_, w| w.lsion().bit(true));
-                let mut i = 0;
-                while rcc.csr2().read().lsirdy().bit_is_clear() {
-                    wait_hang!(i);
-                }
+                bounded_loop!(
+                    rcc.csr2().read().lsirdy().bit_is_clear(),
+                    Error::RegisterUnchanged
+                );
                 rcc.cfgr()
                     .modify(|_, w| unsafe { w.sw().bits(self.input_src.bits()) });
             }
@@ -1382,10 +1382,10 @@ impl Clocks {
             #[cfg(feature = "c0")]
             InputSrc::Lse => {
                 rcc.csr1().modify(|_, w| w.lseon().bit(true));
-                let mut i = 0;
-                while rcc.csr1().read().lserdy().bit_is_clear() {
-                    wait_hang!(i);
-                }
+                bounded_loop!(
+                    rcc.csr1().read().lserdy().bit_is_clear(),
+                    Error::RegisterUnchanged
+                );
                 rcc.cfgr()
                     .modify(|_, w| unsafe { w.sw().bits(self.input_src.bits()) });
             }
@@ -1538,7 +1538,8 @@ impl Clocks {
     cfg_if! {
         if #[cfg(any(feature = "g0", feature = "wl"))] {
             pub const fn usb(&self) -> u32 {
-                unimplemented!("No USB on G0 or WL");
+                // "No USB on G0 or WL"
+                unimplemented!();
             }
         } else if #[cfg(any(feature = "g4", feature = "c071"))] {
             pub const fn usb(&self) -> u32 {

--- a/src/clocks/mod.rs
+++ b/src/clocks/mod.rs
@@ -34,10 +34,9 @@ cfg_if::cfg_if! {
 // todo: Continue working through DRY between the clock modules.
 
 /// Speed out of limits.
-#[derive(Clone, Copy, Debug, defmt::Format)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, defmt::Format)]
 pub enum RccError {
     Speed,
-    Hardware,
 }
 
 // #[derive(Clone, Copy)]

--- a/src/crc.rs
+++ b/src/crc.rs
@@ -6,7 +6,10 @@ use core::{convert::TryInto, fmt};
 
 use cfg_if::cfg_if;
 
-use crate::pac::{CRC, RCC};
+use crate::{
+    error::{Error, Result},
+    pac::{CRC, RCC},
+};
 
 // todo: Redo this in the style of the rest of our modules.
 
@@ -228,26 +231,26 @@ pub struct Polynomial(Poly);
 impl Polynomial {
     /// Create a 7-bit polynomial. Returns an error if the polynomial passed
     /// has the MSB set or is even.
-    pub fn bits7(poly: u8) -> Result<Self, PolynomialError> {
+    pub fn bits7(poly: u8) -> Result<Self> {
         if poly <= 0x7F {
             Ok(Self(Poly::B7(ensure_is_odd!(poly)?)))
         } else {
-            Err(PolynomialError::TooLarge)
+            Err(Error::PolynomialError(PolynomialError::TooLarge))
         }
     }
 
     /// Create an 8-bit polynomial. Returns an error if the polynomial passed is even.
-    pub fn bits8(poly: u8) -> Result<Self, PolynomialError> {
+    pub fn bits8(poly: u8) -> Result<Self> {
         Ok(Self(Poly::B8(ensure_is_odd!(poly)?)))
     }
 
     /// Create a 16-bit polynomial. Returns an error if the polynomial passed is even.
-    pub fn bits16(poly: u16) -> Result<Self, PolynomialError> {
+    pub fn bits16(poly: u16) -> Result<Self> {
         Ok(Self(Poly::B16(ensure_is_odd!(poly)?)))
     }
 
     /// Create a 32-bit polynomial. Returns an error if the polynomial passed is even.
-    pub fn bits32(poly: u32) -> Result<Self, PolynomialError> {
+    pub fn bits32(poly: u32) -> Result<Self> {
         Ok(Self(Poly::B32(ensure_is_odd!(poly)?)))
     }
 
@@ -314,7 +317,7 @@ impl Default for Polynomial {
 }
 
 /// Errors generated when trying to create invalid polynomials.
-#[derive(Copy, Clone, Debug, PartialEq, defmt::Format)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, defmt::Format)]
 pub enum PolynomialError {
     /// Tried to create an even polynomial.
     /// The hardware CRC unit only supports odd polynomials.

--- a/src/dac.rs
+++ b/src/dac.rs
@@ -6,6 +6,7 @@ use core::ops::Deref;
 use cortex_m::delay::Delay;
 
 use crate::{
+    error::Result,
     pac::{self, RCC},
     util::RccPeriph,
 };
@@ -405,7 +406,7 @@ where
         channel_cfg: ChannelCfg,
         dma_periph: dma::DmaPeriph,
         // dma: &mut Dma<D>,
-    ) {
+    ) -> Result<()> {
         // where
         // D: Deref<Target = dma_p::RegisterBlock>,
         // {
@@ -499,7 +500,7 @@ where
                     dma::DataSize::S16,
                     dma::DataSize::S16,
                     channel_cfg,
-                );
+                )
             }
             #[cfg(dma2)]
             dma::DmaPeriph::Dma2 => {
@@ -514,7 +515,7 @@ where
                     dma::DataSize::S16,
                     dma::DataSize::S16,
                     channel_cfg,
-                );
+                )
             }
         }
     }

--- a/src/dfsdm.rs
+++ b/src/dfsdm.rs
@@ -26,9 +26,12 @@ cfg_if! {
 
 #[cfg(any(feature = "f3", feature = "l4"))]
 use crate::dma::DmaInput;
-#[cfg(not(any(feature = "f4", feature = "l552")))]
-use crate::dma::{self, ChannelCfg, DmaChannel};
 use crate::pac::DMA1;
+#[cfg(not(any(feature = "f4", feature = "l552")))]
+use crate::{
+    dma::{self, ChannelCfg, DmaChannel},
+    error::Result,
+};
 
 #[derive(Clone, Copy)]
 #[repr(usize)]
@@ -538,7 +541,7 @@ where
         channel_cfg: ChannelCfg,
         dma_periph: dma::DmaPeriph,
         // dma: &mut Dma<D>,
-    ) {
+    ) -> Result<()> {
         // where
         //     D: Deref<Target = dma_p::RegisterBlock>,
         // {
@@ -599,7 +602,7 @@ where
                     dma::DataSize::S32, // For 24 bits
                     dma::DataSize::S32,
                     channel_cfg,
-                );
+                )?;
             }
             dma::DmaPeriph::Dma2 => {
                 let mut regs = unsafe { &(*pac::DMA2::ptr()) };
@@ -613,9 +616,11 @@ where
                     dma::DataSize::S32, // For 24 bits
                     dma::DataSize::S32,
                     channel_cfg,
-                );
+                )?;
             }
         }
+
+        Ok(())
     }
 
     /// Enable a specific type of interrupt. See H743 RM, section 30.5: DFSDM interrupts

--- a/src/dma.rs
+++ b/src/dma.rs
@@ -21,6 +21,8 @@ cfg_if! {
         all(feature = "g0", not(any(feature = "g0b0", feature = "g0b1", feature = "g0c1")))
     ))] {
         use crate::{pac::{dma1, DMA1}, util::rcc_en_reset};
+    } else if #[cfg(feature = "c0")] { // pac bug?
+        use crate::{pac::{dma as dma1, DMA as DMA1}, util::rcc_en_reset};
     } else {
         use crate::{pac::{dma1, dma2, DMA1, DMA2}, util::rcc_en_reset};
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -18,11 +18,14 @@ use crate::flash::FlashError;
     feature = "wl",
     feature = "l5", // todo: PAC errors on some regs.
     feature = "h5",
+    feature = "c0",
 )))]
 use crate::qspi::QspiError;
+#[cfg(not(feature = "c0"))]
+use crate::rtc::RtcError;
 #[cfg(not(feature = "f301"))]
 use crate::spi::SpiError;
-use crate::{clocks::RccError, i2c::I2cError, rtc::RtcError, timer::TimerError, usart::UsartError};
+use crate::{clocks::RccError, i2c::I2cError, timer::TimerError, usart::UsartError};
 
 macro_rules! impl_from_error {
     ($error:ident) => {
@@ -60,6 +63,7 @@ pub enum Error {
     /// SPI errors.
     SpiError(SpiError),
     /// Clock errors.
+    #[cfg(not(feature = "c0"))]
     RtcError(RtcError),
     RccError(RccError),
     #[cfg(not(any(
@@ -74,6 +78,7 @@ pub enum Error {
         feature = "wl",
         feature = "l5", // todo: PAC errors on some regs.
         feature = "h5",
+        feature = "c0",
     )))]
     QspiError(QspiError),
 }
@@ -89,6 +94,7 @@ impl_from_error!(FlashError);
 impl_from_error!(PolynomialError);
 #[cfg(not(feature = "f301"))]
 impl_from_error!(SpiError);
+#[cfg(not(feature = "c0"))]
 impl_from_error!(RtcError);
 impl_from_error!(RccError);
 #[cfg(not(any(
@@ -103,6 +109,7 @@ impl_from_error!(RccError);
     feature = "wl",
     feature = "l5", // todo: PAC errors on some regs.
     feature = "h5",
+    feature = "c0",
 )))]
 impl_from_error!(QspiError);
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,164 @@
+//! Common error definitions.
+
+#[cfg(not(any(feature = "f", feature = "wb", feature = "wl", feature = "h5")))]
+use crate::crc::PolynomialError;
+#[cfg(not(any(feature = "l552", feature = "h5", feature = "f4")))]
+use crate::dma::DmaError;
+#[cfg(not(feature = "h735"))]
+use crate::flash::FlashError;
+#[cfg(not(any(
+    feature = "f",
+    feature = "l4x3", // todo: PAC bug?
+    feature = "g0",
+    feature = "g431",
+    feature = "g441",
+    feature = "g471",
+    feature = "g491",
+    feature = "g4a1",
+    feature = "wl",
+    feature = "l5", // todo: PAC errors on some regs.
+    feature = "h5",
+)))]
+use crate::qspi::QspiError;
+#[cfg(not(feature = "f301"))]
+use crate::spi::SpiError;
+use crate::{clocks::RccError, i2c::I2cError, rtc::RtcError, timer::TimerError, usart::UsartError};
+
+macro_rules! impl_from_error {
+    ($error:ident) => {
+        impl From<$error> for Error {
+            fn from(error: $error) -> Self {
+                Self::$error(error)
+            }
+        }
+    };
+}
+
+/// Alias for Result<T, Error>.
+pub type Result<T> = core::result::Result<T, Error>;
+
+/// Collection of all errors that can occur.
+#[derive(Debug, Clone, Copy, Eq, PartialEq, defmt::Format)]
+pub enum Error {
+    /// Occurs when an expected change of a register does happen in time.
+    ///
+    /// This is returned when a bounded loop exceeds its alotted iteration count.
+    RegisterUnchanged,
+    #[cfg(not(any(feature = "l552", feature = "h5", feature = "f4")))]
+    /// Direct Memory Access (DMA) error
+    DmaError(DmaError),
+    I2cError(I2cError),
+    UsartError(UsartError),
+    TimerError(TimerError),
+    ///
+    #[cfg(not(feature = "h735"))]
+    FlashError(FlashError),
+    #[cfg(not(any(feature = "f", feature = "wb", feature = "wl", feature = "h5")))]
+    /// CRC
+    PolynomialError(PolynomialError),
+    #[cfg(not(feature = "f301"))]
+    /// SPI errors.
+    SpiError(SpiError),
+    /// Clock errors.
+    RtcError(RtcError),
+    RccError(RccError),
+    #[cfg(not(any(
+        feature = "f",
+        feature = "l4x3", // todo: PAC bug?
+        feature = "g0",
+        feature = "g431",
+        feature = "g441",
+        feature = "g471",
+        feature = "g491",
+        feature = "g4a1",
+        feature = "wl",
+        feature = "l5", // todo: PAC errors on some regs.
+        feature = "h5",
+    )))]
+    QspiError(QspiError),
+}
+
+#[cfg(not(any(feature = "l552", feature = "h5", feature = "f4")))]
+impl_from_error!(DmaError);
+impl_from_error!(I2cError);
+impl_from_error!(UsartError);
+impl_from_error!(TimerError);
+#[cfg(not(feature = "h735"))]
+impl_from_error!(FlashError);
+#[cfg(not(any(feature = "f", feature = "wb", feature = "wl", feature = "h5")))]
+impl_from_error!(PolynomialError);
+#[cfg(not(feature = "f301"))]
+impl_from_error!(SpiError);
+impl_from_error!(RtcError);
+impl_from_error!(RccError);
+#[cfg(not(any(
+    feature = "f",
+    feature = "l4x3", // todo: PAC bug?
+    feature = "g0",
+    feature = "g431",
+    feature = "g441",
+    feature = "g471",
+    feature = "g491",
+    feature = "g4a1",
+    feature = "wl",
+    feature = "l5", // todo: PAC errors on some regs.
+    feature = "h5",
+)))]
+impl_from_error!(QspiError);
+
+#[cfg(feature = "embedded_hal")]
+mod embedded_io_impl {
+    use super::{Error, I2cError, UsartError};
+    use embedded_hal::i2c::{Error as I2cEhError, ErrorKind as I2cErrorKind, NoAcknowledgeSource};
+    use embedded_io::{Error as IoError, ErrorKind as IoErrorKind};
+
+    // Other,
+    // NotFound,
+    // PermissionDenied,
+    // ConnectionRefused,
+    // ConnectionReset,
+    // ConnectionAborted,
+    // NotConnected,
+    // AddrInUse,
+    // AddrNotAvailable,
+    // BrokenPipe,
+    // AlreadyExists,
+    // InvalidInput,
+    // InvalidData,
+    // TimedOut,
+    // Interrupted,
+    // Unsupported,
+    // OutOfMemory,
+    // WriteZero,
+
+    impl I2cEhError for Error {
+        fn kind(&self) -> I2cErrorKind {
+            match self {
+                Error::I2cError(i) => match i {
+                    I2cError::Bus => I2cErrorKind::Bus,
+                    I2cError::Arbitration => I2cErrorKind::ArbitrationLoss,
+                    I2cError::Nack => I2cErrorKind::NoAcknowledge(NoAcknowledgeSource::Unknown),
+                    I2cError::Overrun => I2cErrorKind::Overrun,
+                    _ => I2cErrorKind::Other,
+                    // I2cError::Other => I2cErrorKind::Other,
+                },
+                _ => I2cErrorKind::Other,
+            }
+        }
+    }
+
+    impl IoError for Error {
+        fn kind(&self) -> IoErrorKind {
+            match self {
+                Error::RegisterUnchanged => IoErrorKind::TimedOut,
+                Error::UsartError(u) => match u {
+                    UsartError::Framing => IoErrorKind::Other,
+                    UsartError::Noise => IoErrorKind::Other,
+                    UsartError::Overrun => IoErrorKind::OutOfMemory,
+                    UsartError::Parity => IoErrorKind::InvalidData,
+                },
+                _ => IoErrorKind::Other,
+            }
+        }
+    }
+}

--- a/src/flash/mod.rs
+++ b/src/flash/mod.rs
@@ -40,6 +40,21 @@ cfg_if! {
     }
 }
 
+#[derive(Debug, Clone, Copy, Eq, PartialEq, defmt::Format)]
+/// Possible error states for flash operations.
+pub enum FlashError {
+    /// Flash controller is not done yet
+    Busy,
+    /// Error detected (by command execution, or because no command could be executed)
+    Illegal,
+    /// Set during read if ECC decoding logic detects correctable or uncorrectable error
+    EccError,
+    /// Page number is out of range
+    PageOutOfRange,
+    /// (Legal) command failed
+    Failure,
+}
+
 pub struct Flash {
     pub regs: FLASH,
     #[cfg(any(

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -1436,10 +1436,10 @@ pub unsafe fn write_dma(
     dma_channel: DmaChannel,
     channel_cfg: ChannelCfg,
     dma_periph: dma::DmaPeriph,
-) {
+) -> crate::error::Result<()> {
     let (ptr, len) = (buf.as_ptr(), buf.len());
 
-    let periph_addr = &(*(regs(port))).bsrr() as *const _ as u32;
+    let periph_addr = unsafe { &(*(regs(port))).bsrr() as *const _ as u32 };
 
     let num_data = len as u32;
 
@@ -1457,7 +1457,7 @@ pub unsafe fn write_dma(
                 dma::DataSize::S32,
                 dma::DataSize::S32,
                 channel_cfg,
-            );
+            )?;
         }
         #[cfg(dma2)]
         dma::DmaPeriph::Dma2 => {
@@ -1472,9 +1472,10 @@ pub unsafe fn write_dma(
                 dma::DataSize::S32,
                 dma::DataSize::S32,
                 channel_cfg,
-            );
+            )?;
         }
     }
+    Ok(())
 }
 
 #[cfg(not(any(
@@ -1491,10 +1492,10 @@ pub unsafe fn read_dma(
     dma_channel: DmaChannel,
     channel_cfg: ChannelCfg,
     dma_periph: dma::DmaPeriph,
-) {
+) -> crate::error::Result<()> {
     let (ptr, len) = (buf.as_ptr(), buf.len());
 
-    let periph_addr = &(*(regs(port))).idr() as *const _ as u32;
+    let periph_addr = unsafe { &(*(regs(port))).idr() as *const _ as u32 };
 
     // #[cfg(feature = "h7")]
     let num_data = len as u32;
@@ -1515,7 +1516,7 @@ pub unsafe fn read_dma(
                 dma::DataSize::S32,
                 dma::DataSize::S32,
                 channel_cfg,
-            );
+            )?;
         }
         #[cfg(not(any(feature = "g0", feature = "c0", feature = "wb")))]
         dma::DmaPeriph::Dma2 => {
@@ -1530,7 +1531,9 @@ pub unsafe fn read_dma(
                 dma::DataSize::S32,
                 dma::DataSize::S32,
                 channel_cfg,
-            );
+            )?;
         }
     }
+
+    Ok(())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -145,8 +145,7 @@
 
 // todo: H7B3 has too many changes in v14 PAC; not supporting at this time. (2021-10-07)
 
-// Used for while loops, to allow returning an error instead of hanging.
-pub(crate) const MAX_ITERS: u32 = 300_000; // todo: What should this be?
+// TODO: Unify the different error types into a more sensible structure.
 
 #[cfg(not(any(
     feature = "f301",
@@ -406,6 +405,8 @@ pub mod dfsdm;
 #[cfg(not(feature = "f4"))]
 pub mod dma;
 
+pub mod error;
+
 #[cfg(all(feature = "h7", feature = "net"))]
 pub mod ethernet;
 
@@ -443,18 +444,18 @@ pub mod power;
 // F3, F4, G0, and WL don't have Quad SPI. L5 and newer H variants (eg H735) use OctoSPI,
 // also supported by this module.
 #[cfg(not(any(
-feature = "f",
-feature = "l4x3", // todo: PAC bug?
-feature = "g0",
-feature = "g431",
-feature = "g441",
-feature = "g471",
-feature = "g491",
-feature = "g4a1",
-feature = "wl",
-feature = "l5", // todo: PAC errors on some regs.
-feature = "h5",
-feature = "c0",
+    feature = "f",
+    feature = "l4x3", // todo: PAC bug?
+    feature = "g0",
+    feature = "g431",
+    feature = "g441",
+    feature = "g471",
+    feature = "g491",
+    feature = "g4a1",
+    feature = "wl",
+    feature = "l5", // todo: PAC errors on some regs.
+    feature = "h5",
+    feature = "c0",
 )))]
 pub mod qspi;
 

--- a/src/lpuart.rs
+++ b/src/lpuart.rs
@@ -13,50 +13,19 @@ use core::ops::Deref;
 
 use cfg_if::cfg_if;
 
-#[cfg(any(feature = "f3", feature = "l4"))]
-use crate::dma::DmaInput;
-#[cfg(not(any(feature = "f4", feature = "l552", feature = "h5")))]
+#[cfg(not(any(feature = "l552", feature = "h5")))]
 use crate::dma::{self, ChannelCfg, DmaChannel};
 #[cfg(feature = "g0")]
 use crate::pac::DMA as DMA1;
 #[cfg(not(any(feature = "g0", feature = "h5")))]
 use crate::pac::DMA1;
 use crate::{
-    MAX_ITERS,
     clocks::Clocks,
+    error::{Error, Result},
     pac::{self, RCC},
-    usart::{OverSampling, Parity, StopBits, UartError, UsartConfig, UsartInterrupt},
-    util::{BaudPeriph, RccPeriph},
+    usart::{Parity, UsartConfig, UsartError, UsartInterrupt},
+    util::{BaudPeriph, RccPeriph, bounded_loop, cr1, isr},
 };
-
-#[cfg(feature = "h5")]
-macro_rules! cr1 {
-    ($regs:expr) => {
-        $regs.cr1_enabled()
-    };
-}
-
-#[cfg(not(feature = "h5"))]
-macro_rules! cr1 {
-    ($regs:expr) => {
-        $regs.cr1()
-    };
-}
-
-// Some variants like H5 and certain G0 variants use separate registers for FIFO
-#[cfg(feature = "h5")]
-macro_rules! isr {
-    ($regs:expr) => {
-        $regs.isr_enabled()
-    };
-}
-
-#[cfg(not(feature = "h5"))]
-macro_rules! isr {
-    ($regs:expr) => {
-        $regs.isr()
-    };
-}
 
 /// Represents the USART peripheral, for serial communications.
 pub struct LpUart<R> {
@@ -71,66 +40,66 @@ where
 {
     /// Initialize a U[s]ART peripheral, including configuration register writes, and enabling and
     /// resetting its RCC peripheral clock. `baud` is the baud rate, in bytes-per-second.
-    pub fn new(regs: R, baud: u32, config: UsartConfig, clock_cfg: &Clocks) -> Self {
+    pub fn new(regs: R, baud: u32, config: UsartConfig, clock_cfg: &Clocks) -> Result<Self> {
         let rcc = unsafe { &(*RCC::ptr()) };
         R::en_reset(rcc);
 
-        let mut result = Self { regs, baud, config };
+        let mut lpuart = Self { regs, baud, config };
 
         // This should already be disabled on power up, but disable here just in case;
         // some bits can't be set with USART enabled.
 
-        result.disable();
+        lpuart.disable()?;
 
         // Set up transmission. See L44 RM, section 38.5.2: "Character Transmission Procedures".
         // 1. Program the M bits in USART_CR1 to define the word length.
 
-        let word_len_bits = result.config.word_len.bits();
-        cr1!(result.regs).modify(|_, w| {
-            w.pce().bit(result.config.parity != Parity::Disabled);
+        let word_len_bits = lpuart.config.word_len.bits();
+        cr1!(lpuart.regs).modify(|_, w| {
+            w.pce().bit(lpuart.config.parity != Parity::Disabled);
             cfg_if! {
                 if #[cfg(not(any(feature = "f", feature = "wl")))] {
                     w.m1().bit(word_len_bits.0 != 0);
                     w.m0().bit(word_len_bits.1 != 0);
-                    return w.ps().bit(result.config.parity == Parity::EnabledOdd);
+                    return w.ps().bit(lpuart.config.parity == Parity::EnabledOdd);
                 } else {
-                    return w.ps().bit(result.config.parity == Parity::EnabledOdd);
+                    return w.ps().bit(lpuart.config.parity == Parity::EnabledOdd);
                 }
             }
         });
 
         // todo: Workaround due to a PAC bug, where M0 is missing.
         #[cfg(any(feature = "f"))]
-        result.regs.cr1().write(|w| unsafe {
+        lpuart.regs.cr1().write(|w| unsafe {
             w.bits(
-                result.regs.cr1().read().bits()
+                lpuart.regs.cr1().read().bits()
                     | ((word_len_bits.0 as u32) << 28)
                     | ((word_len_bits.1 as u32) << 12),
             )
         });
 
         #[cfg(not(feature = "f4"))]
-        result
+        lpuart
             .regs
             .cr3()
-            .modify(|_, w| w.ovrdis().bit(result.config.overrun_disabled));
+            .modify(|_, w| w.ovrdis().bit(lpuart.config.overrun_disabled));
 
         // Must be done before enabling.
         #[cfg(any(feature = "g4", feature = "h7"))]
-        result
+        lpuart
             .regs
             .cr1()
-            .modify(|_, w| w.fifoen().bit(result.config.fifo_enabled));
+            .modify(|_, w| w.fifoen().bit(lpuart.config.fifo_enabled));
 
         // 2. Select the desired baud rate using the USART_BRR register.
-        result.set_baud(baud, clock_cfg).ok();
+        lpuart.set_baud(baud, clock_cfg).ok();
         // 3. Program the number of stop bits in USART_CR2.
-        result
+        lpuart
             .regs
             .cr2()
-            .modify(|_, w| unsafe { w.stop().bits(result.config.stop_bits as u8) });
+            .modify(|_, w| unsafe { w.stop().bits(lpuart.config.stop_bits as u8) });
         // 4. Enable the USART by writing the UE bit in USART_CR1 register to 1.
-        result.enable();
+        lpuart.enable()?;
 
         // 5. Select DMA enable (DMAT[R]] in USART_CR3 if multibuffer communication is to take
         // place. Configure the DMA register as explained in multibuffer communication.
@@ -139,12 +108,12 @@ where
         // 6. Set the RE bit USART_CR1. This enables the receiver which begins searching for a
         // start bit.
 
-        cr1!(result.regs).modify(|_, w| {
+        cr1!(lpuart.regs).modify(|_, w| {
             w.te().bit(true);
             w.re().bit(true)
         });
 
-        result
+        Ok(lpuart)
     }
 }
 
@@ -154,18 +123,15 @@ where
 {
     /// Set the BAUD rate. Called during init, and can be called later to change BAUD
     /// during program execution.
-    pub fn set_baud(&mut self, baud: u32, clock_cfg: &Clocks) -> Result<(), UartError> {
+    pub fn set_baud(&mut self, baud: u32, clock_cfg: &Clocks) -> Result<()> {
         let originally_enabled = cr1!(self.regs).read().ue().bit_is_set();
 
         if originally_enabled {
             cr1!(self.regs).modify(|_, w| w.ue().clear_bit());
-            let mut i = 0;
-            while cr1!(self.regs).read().ue().bit_is_set() {
-                i += 1;
-                if i >= MAX_ITERS {
-                    return Err(UartError::Hardware);
-                }
-            }
+            bounded_loop!(
+                cr1!(self.regs).read().ue().bit_is_set(),
+                Error::RegisterUnchanged
+            );
         }
 
         // To set BAUD rate, see G4 RM, section 38.4.7: LPUART baud rate generation.
@@ -205,86 +171,67 @@ where
     R: Deref<Target = pac::lpuart1::RegisterBlock> + RccPeriph,
 {
     /// Enable this U[s]ART peripheral.
-    pub fn enable(&mut self) {
-        cr1!(self.regs).modify(|_, w| w.ue().bit(true));
-        while cr1!(self.regs).read().ue().bit_is_clear() {}
+    pub fn enable(&mut self) -> Result<()> {
+        cr1!(self.regs).modify(|_, w| w.ue().set_bit());
+        bounded_loop!(
+            cr1!(self.regs).read().ue().bit_is_clear(),
+            Error::RegisterUnchanged
+        );
+        Ok(())
     }
 
     /// Disable this U[s]ART peripheral.
-    pub fn disable(&mut self) {
+    pub fn disable(&mut self) -> Result<()> {
         cr1!(self.regs).modify(|_, w| w.ue().clear_bit());
-        while cr1!(self.regs).read().ue().bit_is_set() {}
+        bounded_loop!(
+            cr1!(self.regs).read().ue().bit_is_set(),
+            Error::RegisterUnchanged
+        );
+        Ok(())
     }
 
     /// Transmit data, as a sequence of u8. See L44 RM, section 38.5.2: "Character transmission procedure"
-    pub fn write(&mut self, data: &[u8]) -> Result<(), UartError> {
+    pub fn write(&mut self, data: &[u8]) -> Result<()> {
         // todo: how does this work with a 9 bit words? Presumably you'd need to make `data`
         // todo take `&u16`.
 
         // 7. Write the data to send in the USART_TDR register (this clears the TXE bit). Repeat this
         // for each data to be transmitted in case of single buffer.
 
-        cfg_if! {
-            if #[cfg(not(feature = "f4"))] {
-                for word in data {
-                    let mut i = 0;
+        for word in data {
+            #[cfg(feature = "h5")]
+            bounded_loop!(
+                isr!(self.regs).read().txfe().bit_is_clear(),
+                Error::RegisterUnchanged
+            );
 
-                    #[cfg(feature = "h5")]
-                    while isr!(self.regs).read().txfe().bit_is_clear() {
-                        i += 1;
-                        if i >= MAX_ITERS {
-                            // return Err(UartError::Hardware);
-                        }
-                    }
+            #[cfg(not(feature = "h5"))]
+            // Note: Per these PACs, TXFNF and TXE are on the same field, so this is actually
+            // checking txfnf if the fifo is enabled.
+            bounded_loop!(
+                isr!(self.regs).read().txe().bit_is_clear(),
+                Error::RegisterUnchanged
+            );
 
-                    #[cfg(not(feature = "h5"))]
-                    // Note: Per these PACs, TXFNF and TXE are on the same field, so this is actually
-                    // checking txfnf if the fifo is enabled.
-                    while isr!(self.regs).read().txe().bit_is_clear() {
-                        i += 1;
-                        if i >= MAX_ITERS {
-                            return Err(UartError::Hardware);
-                        }
-                    }
+            #[cfg(not(feature = "f4"))]
+            self.regs
+                .tdr()
+                .modify(|_, w| unsafe { w.tdr().bits(*word as u16) });
 
-                    self.regs
-                        .tdr()
-                        .modify(|_, w| unsafe { w.tdr().bits(*word as u16) });
-                }
-                // 8. After writing the last data into the USART_TDR register, wait until TC=1. This indicates
-                // that the transmission of the last frame is complete. This is required for instance when
-                // the USART is disabled or enters the Halt mode to avoid corrupting the last
-                // transmission
-                let mut i = 0;
-                while isr!(self.regs).read().tc().bit_is_clear() {
-                        i += 1;
-                        if i >= MAX_ITERS {
-                            return Err(UartError::Hardware);
-                        }
-                }
-            } else {
-                for word in data {
-                    let mut i = 0;
-                    while self.regs.sr().read().txe().bit_is_clear() {
-                        i += 1;
-                        if i >= MAX_ITERS {
-                            return Err(UartError::Hardware);
-                        }
-                    }
-                    self.regs
-                        .dr
-                        .modify(|_, w| unsafe { w.dr().bits(*word as u16) });
-
-                }
-                let mut i = 0;
-                while self.regs.sr().read().tc().bit_is_clear() {
-                                            i += 1;
-                        if i >= MAX_ITERS {
-                            return Err(UartError::Hardware);
-                        }
-                }
-            }
+            #[cfg(feature = "f4")]
+            self.regs
+                .dr()
+                .modify(|_, w| unsafe { w.dr().bits(*word as u16) });
         }
+
+        // 8. After writing the last data into the USART_TDR register, wait until TC=1. This indicates
+        // that the transmission of the last frame is complete. This is required for instance when
+        // the USART is disabled or enters the Halt mode to avoid corrupting the last
+        // transmission
+        bounded_loop!(
+            isr!(self.regs).read().tc().bit_is_clear(),
+            Error::RegisterUnchanged
+        );
 
         Ok(())
     }
@@ -308,39 +255,28 @@ where
     }
 
     /// Receive data into a u8 buffer. See L44 RM, section 38.5.3: "Character reception procedure"
-    pub fn read(&mut self, buf: &mut [u8]) -> Result<(), UartError> {
+    pub fn read(&mut self, buf: &mut [u8]) -> Result<()> {
         for i in 0..buf.len() {
-            let mut i_ = 0;
-            cfg_if! {
-                if #[cfg(not(feature = "f4"))] {
-                    // Wait for the next bit
+            // Wait for the next bit
+            #[cfg(feature = "h5")]
+            bounded_loop!(
+                isr!(self.regs).read().rxfne().bit_is_clear(),
+                Error::RegisterUnchanged
+            );
 
-                    #[cfg(feature = "h5")]
-                    while isr!(self.regs).read().rxfne().bit_is_clear() {
-                        i_ += 1;
-                        if i_ >= MAX_ITERS {
-                            return Err(UartError::Hardware);
-                        }
-                    }
+            #[cfg(not(feature = "h5"))]
+            bounded_loop!(
+                isr!(self.regs).read().rxne().bit_is_clear(),
+                Error::RegisterUnchanged
+            );
 
-                    #[cfg(not(feature = "h5"))]
-                    while isr!(self.regs).read().rxne().bit_is_clear() {
-                        i_ += 1;
-                        if i_ >= MAX_ITERS {
-                            return Err(UartError::Hardware);
-                        }
-                    }
-
-                    buf[i] = self.regs.rdr().read().rdr().bits() as u8;
-                } else {
-                    while self.regs.sr().read().rxne().bit_is_clear() {
-                        i_ += 1;
-                        if i_ >= MAX_ITERS {
-                            return Err(UartError::Hardware);
-                        }
-                    }
-                    buf[i] = self.regs.dr().read().dr().bits() as u8;
-                }
+            #[cfg(not(feature = "f4"))]
+            {
+                buf[i] = self.regs.rdr().read().rdr().bits() as u8;
+            }
+            #[cfg(feature = "f4")]
+            {
+                buf[i] = self.regs.dr().read().dr().bits() as u8;
             }
         }
 
@@ -383,7 +319,7 @@ where
         channel: DmaChannel,
         channel_cfg: ChannelCfg,
         dma_periph: dma::DmaPeriph,
-    ) {
+    ) -> Result<()> {
         let (ptr, len) = (buf.as_ptr(), buf.len());
 
         // To map a DMA channel for USART transmission, use
@@ -430,7 +366,7 @@ where
                     dma::DataSize::S8,
                     dma::DataSize::S8,
                     channel_cfg,
-                );
+                )?;
             }
             #[cfg(not(any(feature = "f3x4", feature = "g0", feature = "wb")))]
             dma::DmaPeriph::Dma2 => {
@@ -445,7 +381,7 @@ where
                     dma::DataSize::S8,
                     dma::DataSize::S8,
                     channel_cfg,
-                );
+                )?;
             }
         }
 
@@ -464,6 +400,7 @@ where
         // disabling the USART or entering Stop mode. Software must wait until TC=1. The TC flag
         // remains cleared during all data transfers and it is set by hardware at the end of transmission
         // of the last frame.
+        Ok(())
     }
 
     #[cfg(not(any(feature = "f4", feature = "l552", feature = "h5")))]
@@ -476,7 +413,7 @@ where
         channel: DmaChannel,
         channel_cfg: ChannelCfg,
         dma_periph: dma::DmaPeriph,
-    ) {
+    ) -> Result<()> {
         let (ptr, len) = (buf.as_mut_ptr(), buf.len());
 
         #[cfg(any(feature = "f3", feature = "l4"))]
@@ -511,7 +448,7 @@ where
                     dma::DataSize::S8,
                     dma::DataSize::S8,
                     channel_cfg,
-                );
+                )?;
             }
             #[cfg(not(any(feature = "f3x4", feature = "g0", feature = "wb")))]
             dma::DmaPeriph::Dma2 => {
@@ -526,7 +463,7 @@ where
                     dma::DataSize::S8,
                     dma::DataSize::S8,
                     channel_cfg,
-                );
+                )?;
             }
         }
 
@@ -543,6 +480,7 @@ where
 
         // When the number of data transfers programmed in the DMA Controller is reached, the DMA
         // controller generates an interrupt on the DMA channel interrupt vector.
+        Ok(())
     }
     //
     // /// Flush the transmit buffer.
@@ -557,13 +495,16 @@ where
     /// Enable a specific type of interrupt. See G4 RM, Table 349: USART interrupt requests.
     /// If `Some`, the inner value of `CharDetect` sets the address of the char to match.
     /// If `None`, the interrupt is enabled without changing the char to match.
-    pub fn enable_interrupt(&mut self, interrupt: UsartInterrupt) {
+    pub fn enable_interrupt(&mut self, interrupt: UsartInterrupt) -> Result<()> {
         match interrupt {
             UsartInterrupt::CharDetect(char_wrapper) => {
                 if let Some(char) = char_wrapper {
                     // Disable the UART to allow writing the `add` and `addm7` bits
                     cr1!(self.regs).modify(|_, w| w.ue().clear_bit());
-                    while cr1!(self.regs).read().ue().bit_is_set() {}
+                    bounded_loop!(
+                        cr1!(self.regs).read().ue().bit_is_set(),
+                        Error::RegisterUnchanged
+                    );
 
                     // Enable character-detecting UART interrupt
                     cr1!(self.regs).modify(|_, w| w.cmie().bit(true));
@@ -576,7 +517,10 @@ where
                     });
 
                     cr1!(self.regs).modify(|_, w| w.ue().bit(true));
-                    while cr1!(self.regs).read().ue().bit_is_clear() {}
+                    bounded_loop!(
+                        cr1!(self.regs).read().ue().bit_is_clear(),
+                        Error::RegisterUnchanged
+                    );
                 }
 
                 cr1!(self.regs).modify(|_, w| w.cmie().bit(true));
@@ -613,6 +557,7 @@ where
             }
             _ => panic!(), // UART interrupts not avail on LPUART
         }
+        Ok(())
     }
 
     #[cfg(not(feature = "f4"))]
@@ -710,32 +655,26 @@ where
         }
     }
 
-    fn check_status(&mut self) -> Result<(), UartError> {
-        cfg_if! {
-            if #[cfg(feature = "f4")] {
-                let status = self.regs.sr().read();
-            } else {
-                let status = self.regs.isr().read();
-            }
-        }
+    fn check_status(&mut self) -> Result<()> {
+        let status = isr!(self.regs).read();
         let mut result = if status.pe().bit_is_set() {
-            Err(UartError::Parity)
+            Err(Error::UsartError(UsartError::Parity))
         } else if status.fe().bit_is_set() {
-            Err(UartError::Framing)
+            Err(Error::UsartError(UsartError::Framing))
         } else if status.ore().bit_is_set() {
-            Err(UartError::Overrun)
+            Err(Error::UsartError(UsartError::Overrun))
         } else {
             Ok(())
         };
 
         #[cfg(not(any(feature = "wl", feature = "h7")))]
         if status.nf().bit_is_set() {
-            result = Err(UartError::Noise);
+            result = Err(Error::UsartError(UsartError::Noise));
         }
         #[cfg(feature = "h7")]
         if status.ne().bit_is_set() {
             // todo: QC
-            result = Err(UartError::Noise);
+            result = Err(Error::UsartError(UsartError::Noise));
         }
 
         if result.is_err() {
@@ -761,14 +700,12 @@ where
 
 #[cfg(feature = "embedded_hal")]
 mod embedded_io_impl {
-    use embedded_io::*;
+    use embedded_io::{ErrorType, Read, ReadReady, Write, WriteReady};
 
     use super::*;
 
-    // (Error for Uart implemented in the usart module)
-
     impl<R> ErrorType for LpUart<R> {
-        type Error = UartError;
+        type Error = crate::error::Error;
     }
 
     impl<R> Read for LpUart<R>
@@ -776,7 +713,7 @@ mod embedded_io_impl {
         R: Deref<Target = pac::lpuart1::RegisterBlock> + RccPeriph + BaudPeriph,
         LpUart<R>: ReadReady,
     {
-        fn read(&mut self, mut buf: &mut [u8]) -> Result<usize, Self::Error> {
+        fn read(&mut self, mut buf: &mut [u8]) -> core::result::Result<usize, Self::Error> {
             // Block until at least one byte can be read:
             while !self.read_ready()? {
                 cortex_m::asm::nop();
@@ -796,15 +733,13 @@ mod embedded_io_impl {
     where
         R: Deref<Target = pac::lpuart1::RegisterBlock> + RccPeriph + BaudPeriph,
     {
-        fn read_ready(&mut self) -> Result<bool, Self::Error> {
+        fn read_ready(&mut self) -> core::result::Result<bool, Self::Error> {
             self.check_status()?;
             cfg_if! {
                 if #[cfg(feature = "h5")] {
-                    let ready = self.regs.isr().read().rxfne().bit_is_set();
-                } else if #[cfg(feature = "f4")] {
-                    let ready = self.regs.sr().read().rxne().bit_is_set();
+                    let ready = isr!(self.regs).read().rxfne().bit_is_set();
                 } else {
-                    let ready = self.regs.isr().read().rxne().bit_is_set();
+                    let ready = isr!(self.regs).read().rxne().bit_is_set();
                 }
             };
             Ok(ready)
@@ -815,13 +750,13 @@ mod embedded_io_impl {
     where
         R: Deref<Target = pac::lpuart1::RegisterBlock> + RccPeriph + BaudPeriph,
     {
-        fn write(&mut self, mut buf: &[u8]) -> Result<usize, Self::Error> {
+        fn write(&mut self, mut buf: &[u8]) -> core::result::Result<usize, Self::Error> {
             // Block until at least one byte can be written:
             while !self.write_ready()? {
                 cortex_m::asm::nop();
             }
-
             let buf_len = buf.len();
+
             while !buf.is_empty() && self.write_ready()? {
                 let (byte, remaining) = buf.split_first().unwrap();
                 self.write_one(*byte);
@@ -830,11 +765,11 @@ mod embedded_io_impl {
             Ok(buf_len - buf.len())
         }
 
-        fn flush(&mut self) -> Result<(), Self::Error> {
-            #[cfg(not(feature = "f4"))]
-            while isr!(self.regs).read().tc().bit_is_clear() {}
-            #[cfg(feature = "f4")]
-            while self.regs.sr().read().tc().bit_is_clear() {}
+        fn flush(&mut self) -> core::result::Result<(), Self::Error> {
+            // fixme
+            while isr!(self.regs).read().tc().bit_is_clear() {
+                cortex_m::asm::nop();
+            }
             Ok(())
         }
     }
@@ -843,14 +778,12 @@ mod embedded_io_impl {
     where
         R: Deref<Target = pac::lpuart1::RegisterBlock> + RccPeriph + BaudPeriph,
     {
-        fn write_ready(&mut self) -> Result<bool, Self::Error> {
+        fn write_ready(&mut self) -> core::result::Result<bool, Self::Error> {
             cfg_if! {
                 if #[cfg(feature = "h5")] {
-                    let ready = self.regs.isr().read().txfe().bit_is_set();
-                } else if #[cfg(feature = "f4")] {
-                    let ready = self.regs.sr().read().txe().bit_is_set();
+                    let ready = isr!(self.regs).read().txfe().bit_is_set();
                 } else {
-                    let ready = self.regs.isr().read().txe().bit_is_set();
+                    let ready = isr!(self.regs).read().txe().bit_is_set();
                 }
             };
             Ok(ready)

--- a/src/sai.rs
+++ b/src/sai.rs
@@ -24,7 +24,7 @@ use crate::pac::sai;
 use crate::pac::sai1 as sai;
 #[cfg(feature = "h7")]
 use crate::pac::sai4 as sai;
-use crate::{clocks::Clocks, pac::RCC, util::RccPeriph};
+use crate::{clocks::Clocks, error::Result, pac::RCC, util::RccPeriph};
 
 #[derive(Clone, Copy)]
 #[repr(u8)]
@@ -978,7 +978,8 @@ It can generate an interrupt if WCKCFGIE bit is set in SAI_xIM register");
         dma_channel: DmaChannel,
         channel_cfg: ChannelCfg,
         dma: &mut Dma<D>,
-    ) where
+    ) -> Result<()>
+    where
         D: Deref<Target = dma_p::RegisterBlock>,
     {
         let (ptr, len) = (buf.as_ptr(), buf.len());
@@ -1037,7 +1038,8 @@ It can generate an interrupt if WCKCFGIE bit is set in SAI_xIM register");
             _ => dma::DataSize::S32,
         };
 
-        dma.cfg_channel(
+        dma::cfg_channel(
+            dma,
             dma_channel,
             periph_addr,
             ptr as u32,
@@ -1046,7 +1048,7 @@ It can generate an interrupt if WCKCFGIE bit is set in SAI_xIM register");
             datasize,
             datasize,
             channel_cfg,
-        );
+        )
 
         // 4. Enable the SAI interface. (handled by `Sai::enable() in user code`.)
     }
@@ -1064,7 +1066,8 @@ It can generate an interrupt if WCKCFGIE bit is set in SAI_xIM register");
         dma_channel: DmaChannel,
         channel_cfg: ChannelCfg,
         dma: &mut Dma<D>,
-    ) where
+    ) -> Result<()>
+    where
         D: Deref<Target = dma_p::RegisterBlock>,
     {
         let (ptr, len) = (buf.as_mut_ptr(), buf.len());
@@ -1110,7 +1113,8 @@ It can generate an interrupt if WCKCFGIE bit is set in SAI_xIM register");
             _ => dma::DataSize::S32,
         };
 
-        dma.cfg_channel(
+        dma::cfg_channel(
+            dma,
             dma_channel,
             periph_addr,
             ptr as u32,
@@ -1119,7 +1123,7 @@ It can generate an interrupt if WCKCFGIE bit is set in SAI_xIM register");
             datasize,
             datasize,
             channel_cfg,
-        );
+        )
 
         // 4. Enable the SAI interface. (handled by `Sai::enable() in user code`.)
     }

--- a/src/spi/mod.rs
+++ b/src/spi/mod.rs
@@ -16,11 +16,14 @@ cfg_if::cfg_if! {
 
 use cfg_if::cfg_if;
 
-use crate::{
-    error::Result,
-    pac::{self, DMA1},
-    util::RccPeriph,
-};
+cfg_if! {
+    if #[cfg(feature = "c0")] { // pac bug?
+       use crate::{pac::{self, dma as dma1, DMA as DMA1}, util::rcc_en_reset};
+    } else {
+        use crate::pac::{self, DMA1};
+    }
+}
+use crate::{error::Result, util::RccPeriph};
 
 #[cfg(any(feature = "f3", feature = "l4"))]
 use crate::dma::DmaInput;

--- a/src/usart.rs
+++ b/src/usart.rs
@@ -11,22 +11,35 @@ use core::ops::Deref;
 
 use cfg_if::cfg_if;
 
-#[cfg(any(feature = "f3", feature = "l4"))]
-use crate::dma::DmaInput;
 #[cfg(not(any(feature = "f4", feature = "l552", feature = "h5")))]
 use crate::dma::{self, ChannelCfg, DmaChannel};
 #[cfg(any(feature = "c0", feature = "h5"))]
 use crate::pac::DMA as DMA1;
 #[cfg(not(any(feature = "h5", feature = "c0")))]
 use crate::pac::DMA1;
+// use crate::util::{cr1, isr};
 use crate::{
-    MAX_ITERS,
     clocks::Clocks,
+    error::{Error, Result},
     pac::{self, RCC},
-    util::{BaudPeriph, RccPeriph},
+    util::{BaudPeriph, RccPeriph, bounded_loop, cr1, isr},
 };
 
 // todo: Prescaler (USART_PRESC) register on v3 (L5, G, H etc)
+
+/// Serial error
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, defmt::Format)]
+pub enum UsartError {
+    /// Framing error
+    Framing,
+    /// Noise error
+    Noise,
+    /// RX buffer overrun
+    Overrun,
+    /// Parity check error
+    Parity,
+}
 
 #[derive(Clone, Copy)]
 #[repr(u8)]
@@ -82,21 +95,6 @@ pub enum IrdaMode {
     Normal,
     /// "IrDA SIR 'low-power' mode"
     LowPower,
-}
-
-/// Serial error
-#[non_exhaustive]
-#[derive(Debug, defmt::Format)]
-pub enum UartError {
-    /// Framing error
-    Framing,
-    /// Noise error
-    Noise,
-    /// RX buffer overrun
-    Overrun,
-    /// Parity check error
-    Parity,
-    Hardware,
 }
 
 #[cfg(not(feature = "f4"))]
@@ -164,35 +162,6 @@ impl Default for UsartConfig {
 
 // todo: Support fifo_disabled regs.
 
-#[cfg(feature = "h5")]
-macro_rules! cr1 {
-    ($regs:expr) => {
-        $regs.cr1_enabled()
-    };
-}
-
-#[cfg(not(feature = "h5"))]
-macro_rules! cr1 {
-    ($regs:expr) => {
-        $regs.cr1()
-    };
-}
-
-// Some variants like H5 and certain G0 variants use separate registers for FIFO
-#[cfg(feature = "h5")]
-macro_rules! isr {
-    ($regs:expr) => {
-        $regs.isr()_enabled()
-    };
-}
-
-#[cfg(not(feature = "h5"))]
-macro_rules! isr {
-    ($regs:expr) => {
-        $regs.isr()
-    };
-}
-
 /// Represents the USART peripheral, for serial communications.
 pub struct Usart<R> {
     pub regs: R,
@@ -206,71 +175,61 @@ where
 {
     /// Initialize a U(S)ART peripheral, including configuration register writes, and enabling and
     /// resetting its RCC peripheral clock. `baud` is the baud rate, in bytes-per-second.
-    pub fn new(regs: R, baud: u32, config: UsartConfig, clock_cfg: &Clocks) -> Self {
+    pub fn new(regs: R, baud: u32, config: UsartConfig, clock_cfg: &Clocks) -> Result<Self> {
         let rcc = unsafe { &(*RCC::ptr()) };
         R::en_reset(rcc);
 
-        let mut result = Self { regs, baud, config };
+        let mut usart = Self { regs, baud, config };
 
         // This should already be disabled on power up, but disable here just in case;
         // some bits can't be set with USART enabled.
 
-        result.disable();
+        usart.disable()?;
 
         // Set up transmission. See L44 RM, section 38.5.2: "Character Transmission Procedures".
         // 1. Program the M bits in USART_CR1 to define the word length.
 
-        let word_len_bits = result.config.word_len.bits();
-        cr1!(result.regs).modify(|_, w| {
-            w.over8().bit(result.config.oversampling as u8 != 0);
-            w.pce().bit(result.config.parity != Parity::Disabled);
+        let word_len_bits = usart.config.word_len.bits();
+        cr1!(usart.regs).modify(|_, w| {
+            w.over8().bit(usart.config.oversampling as u8 != 0);
+            w.pce().bit(usart.config.parity != Parity::Disabled);
             cfg_if! {
                 if #[cfg(not(any(feature = "f", feature = "wl")))] {
                     w.m1().bit(word_len_bits.0 != 0);
                     w.m0().bit(word_len_bits.1 != 0);
-                    return w.ps().bit(result.config.parity == Parity::EnabledOdd);
+                    return w.ps().bit(usart.config.parity == Parity::EnabledOdd);
                 } else if #[cfg(feature = "f")] {
                     // todo: QC this.
                     w.m().bit(word_len_bits.0 != 0);
-                    return w.ps().bit(result.config.parity == Parity::EnabledOdd);
+                    return w.ps().bit(usart.config.parity == Parity::EnabledOdd);
                 } else {
-                    return w.ps().bit(result.config.parity == Parity::EnabledOdd);
+                    return w.ps().bit(usart.config.parity == Parity::EnabledOdd);
                 }
             }
         });
 
-        // // todo: Workaround due to a PAC bug, where M0 is missing.
-        // #[cfg(feature = "f")]
-        // result.regs.cr1().write(|w| unsafe {
-        //     w.bits(
-        //         result.regs.cr1().read().bits()
-        //             | ((word_len_bits.0 as u32) << 28)
-        //             | ((word_len_bits.1 as u32) << 12),
-        //     )
-        // });
-
         #[cfg(not(feature = "f4"))]
-        result
+        usart
             .regs
             .cr3()
-            .modify(|_, w| w.ovrdis().bit(result.config.overrun_disabled));
+            .modify(|_, w| w.ovrdis().bit(usart.config.overrun_disabled));
 
         // Must be done before enabling.
         #[cfg(any(feature = "g4", feature = "h7"))]
-        result
+        usart
             .regs
             .cr1()
-            .modify(|_, w| w.fifoen().bit(result.config.fifo_enabled));
+            .modify(|_, w| w.fifoen().bit(usart.config.fifo_enabled));
 
         // 2. Select the desired baud rate using the USART_BRR register.
-        result.set_baud(baud, clock_cfg).ok();
+        usart.set_baud(baud, clock_cfg).ok();
         // 3. Program the number of stop bits in USART_CR2.
-        result
+        usart
             .regs
             .cr2()
-            .modify(|_, w| unsafe { w.stop().bits(result.config.stop_bits as u8) });
+            .modify(|_, w| unsafe { w.stop().bits(usart.config.stop_bits as u8) });
         // 4. Enable the USART by writing the UE bit in USART_CR1 register to 1.
-        result.enable();
+        usart.enable()?;
 
         // 5. Select DMA enable (DMAT[R]] in USART_CR3 if multibuffer communication is to take
         // place. Configure the DMA register as explained in multibuffer communication.
@@ -279,35 +238,35 @@ where
         // 6. Set the RE bit USART_CR1. This enables the receiver which begins searching for a
         // start bit.
 
-        cr1!(result.regs).modify(|_, w| {
+        cr1!(usart.regs).modify(|_, w| {
             w.te().bit(true);
             w.re().bit(true)
         });
 
-        match result.config.irda_mode {
+        match usart.config.irda_mode {
             // See G4 RM, section 37.5.18: USART IrDA SIR ENDEC block
             // " IrDA mode is selected by setting the IREN bit in the USART_CR3 register. In IrDA mode,
             // the following bits must be kept cleared:
             // • LINEN, STOP and CLKEN bits in the USART_CR2 register,
             IrdaMode::None => (),
             _ => {
-                result.regs.cr2().modify(|_, w| unsafe {
+                usart.regs.cr2().modify(|_, w| unsafe {
                     w.linen().clear_bit();
                     w.stop().bits(0);
                     w.clken().clear_bit()
                 });
 
                 // • SCEN and HDSEL bits in the USART_CR3 register."
-                result.regs.cr3().modify(|_, w| {
+                usart.regs.cr3().modify(|_, w| {
                     w.scen().clear_bit();
                     w.hdsel().clear_bit();
-                    w.irlp().bit(result.config.irda_mode == IrdaMode::LowPower);
+                    w.irlp().bit(usart.config.irda_mode == IrdaMode::LowPower);
                     w.iren().bit(true)
                 });
             }
         }
 
-        result
+        Ok(usart)
     }
 }
 
@@ -317,18 +276,15 @@ where
 {
     /// Set the BAUD rate. Called during init, and can be called later to change BAUD
     /// during program execution.
-    pub fn set_baud(&mut self, baud: u32, clock_cfg: &Clocks) -> Result<(), UartError> {
+    pub fn set_baud(&mut self, baud: u32, clock_cfg: &Clocks) -> Result<()> {
         let originally_enabled = cr1!(self.regs).read().ue().bit_is_set();
 
         if originally_enabled {
             cr1!(self.regs).modify(|_, w| w.ue().clear_bit());
-            let mut i = 0;
-            while cr1!(self.regs).read().ue().bit_is_set() {
-                i += 1;
-                if i >= MAX_ITERS {
-                    return Err(UartError::Hardware);
-                }
-            }
+            bounded_loop!(
+                cr1!(self.regs).read().ue().bit_is_set(),
+                Error::RegisterUnchanged
+            );
         }
 
         // To set BAUD rate, see L4 RM section 38.5.4: "USART baud rate generation".
@@ -373,83 +329,82 @@ where
     R: Deref<Target = pac::usart1::RegisterBlock> + RccPeriph,
 {
     /// Enable this U(S)ART peripheral.
-    pub fn enable(&mut self) {
+    pub fn enable(&mut self) -> Result<()> {
         cr1!(self.regs).modify(|_, w| w.ue().bit(true));
-        while cr1!(self.regs).read().ue().bit_is_clear() {}
+        bounded_loop!(
+            cr1!(self.regs).read().ue().bit_is_clear(),
+            Error::RegisterUnchanged
+        );
+
+        Ok(())
     }
 
     /// Disable this U(S)ART peripheral.
-    pub fn disable(&mut self) {
+    pub fn disable(&mut self) -> Result<()> {
         cr1!(self.regs).modify(|_, w| w.ue().clear_bit());
-        while cr1!(self.regs).read().ue().bit_is_set() {}
+        bounded_loop!(
+            cr1!(self.regs).read().ue().bit_is_set(),
+            Error::RegisterUnchanged
+        );
+        Ok(())
     }
 
     /// Transmit data, as a sequence of u8. See L44 RM, section 38.5.2: "Character transmission procedure"
-    pub fn write(&mut self, data: &[u8]) -> Result<(), UartError> {
+    pub fn write(&mut self, data: &[u8]) -> Result<()> {
         // todo: how does this work with a 9 bit words? Presumably you'd need to make `data`
         // todo take `&u16`.
 
         // 7. Write the data to send in the USART_TDR register (this clears the TXE bit). Repeat this
         // for each data to be transmitted in case of single buffer.
 
-        cfg_if! {
-            if #[cfg(not(feature = "f4"))] {
-                for word in data {
-                    let mut i = 0;
-
-                    #[cfg(any(feature = "h5", feature = "c0", feature = "g050", feature = "g051", feature = "g061"))]
-                    while isr!(self.regs).read().txfe().bit_is_clear() {
-                        i += 1;
-                        if i >= MAX_ITERS {
-                            // return Err(UartError::Hardware);
-                        }
-                    }
-
-                    #[cfg(not(any(feature = "h5", feature = "c0", feature = "g050", feature = "g051", feature = "g061")))]
-                    // Note: Per these PACs, TXFNF and TXE are on the same field, so this is actually
-                    // checking txfnf if the fifo is enabled.
-                    while isr!(self.regs).read().txe().bit_is_clear() {
-                        i += 1;
-                        if i >= MAX_ITERS {
-                            return Err(UartError::Hardware);
-                        }
-                    }
-
-                    self.regs
-                        .tdr()
-                        .modify(|_, w| unsafe { w.tdr().bits(*word as u16) });
+        for word in data {
+            cfg_if! {
+                if #[cfg(any(
+                    feature = "h5",
+                    feature = "g050",
+                    feature = "g051",
+                    feature = "g061"
+                ))] {
+                    bounded_loop!(
+                        isr!(self.regs).read().txfe().bit_is_clear(),
+                        Error::RegisterUnchanged
+                    );
+                } else if #[cfg(feature = "f4")] {
+                    bounded_loop!(
+                        isr!(self.regs).read().tc().bit_is_clear(),
+                        Error::RegisterUnchanged
+                    );
+                    bounded_loop!(
+                        isr!(self.regs).read().txe().bit_is_clear(),
+                        Error::RegisterUnchanged
+                    );
+                } else {
+                    bounded_loop!(
+                        isr!(self.regs).read().txe().bit_is_clear(),
+                        Error::RegisterUnchanged
+                    );
                 }
-                // 8. After writing the last data into the USART_TDR register, wait until TC=1. This indicates
-                // that the transmission of the last frame is complete. This is required for instance when
-                // the USART is disabled or enters the Halt mode to avoid corrupting the last
-                // transmission
-                let mut i = 0;
-                while isr!(self.regs).read().tc().bit_is_clear() {
-                        i += 1;
-                        if i >= MAX_ITERS {
-                            return Err(UartError::Hardware);
-                        }
-                }
-            } else {
-                for word in data {
-                    let mut i = 0;
-                    while self.regs.sr().read().txe().bit_is_clear() {
-                        i += 1;
-                        if i >= MAX_ITERS {
-                            return Err(UartError::Hardware);
-                        }
-                    }
+            }
+
+            // 8. After writing the last data into the USART_TDR register, wait until TC=1. This indicates
+            // that the transmission of the last frame is complete. This is required for instance when
+            // the USART is disabled or enters the Halt mode to avoid corrupting the last
+            // transmission
+            cfg_if! {
+                if #[cfg(feature = "f4")] {
                     self.regs
                         .dr()
                         .modify(|_, w| unsafe { w.dr().bits(*word as u16) });
-
-                }
-                let mut i = 0;
-                while self.regs.sr().read().tc().bit_is_clear() {
-                                            i += 1;
-                        if i >= MAX_ITERS {
-                            return Err(UartError::Hardware);
-                        }
+                    bounded_loop!(
+                        self.regs.sr().read().tc().bit_is_clear(),
+                        Error::RegisterUnchanged
+                    );
+                } else {
+                    // Note: Per these PACs, TXFNF and TXE are on the same field, so this is actually
+                    // checking txfnf if the fifo is enabled.
+                    self.regs
+                        .tdr()
+                        .modify(|_, w| unsafe { w.tdr().bits(*word as u16) });
                 }
             }
         }
@@ -476,39 +431,36 @@ where
     }
 
     /// Receive data into a u8 buffer. See L44 RM, section 38.5.3: "Character reception procedure"
-    pub fn read(&mut self, buf: &mut [u8]) -> Result<(), UartError> {
+    pub fn read(&mut self, buf: &mut [u8]) -> Result<()> {
         for i in 0..buf.len() {
-            let mut i_ = 0;
+            // Wait for the next bit
+
             cfg_if! {
-                if #[cfg(not(feature = "f4"))] {
-                    // Wait for the next bit
-
-                    #[cfg(any(feature = "h5", feature = "c0", feature = "g050", feature = "g051", feature = "g061"))]
-                    while isr!(self.regs).read().rxfne().bit_is_clear() {
-                        i_ += 1;
-                        if i_ >= MAX_ITERS {
-                            return Err(UartError::Hardware);
-                        }
-                    }
-
-                    #[cfg(not(any(feature = "h5", feature = "c0", feature = "g050", feature = "g051", feature = "g061")))]
-                    while isr!(self.regs).read().rxne().bit_is_clear() {
-                        i_ += 1;
-                        if i_ >= MAX_ITERS {
-                            return Err(UartError::Hardware);
-                        }
-                    }
-
-                    buf[i] = self.regs.rdr().read().rdr().bits() as u8;
+                if #[cfg(any(
+                    feature = "h5",
+                    feature = "g050",
+                    feature = "g051",
+                    feature = "g061"
+                ))] {
+                    bounded_loop!(
+                        isr!(self.regs).read().rxfne().bit_is_clear(),
+                        Error::RegisterUnchanged
+                    );
                 } else {
-                    while self.regs.sr().read().rxne().bit_is_clear() {
-                        i_ += 1;
-                        if i_ >= MAX_ITERS {
-                            return Err(UartError::Hardware);
-                        }
-                    }
-                    buf[i] = self.regs.dr().read().dr().bits() as u8;
+                    bounded_loop!(
+                        isr!(self.regs).read().rxne().bit_is_clear(),
+                        Error::RegisterUnchanged
+                    );
                 }
+            }
+
+            #[cfg(not(feature = "f4"))]
+            {
+                buf[i] = self.regs.rdr().read().rdr().bits() as u8;
+            }
+            #[cfg(feature = "f4")]
+            {
+                buf[i] = self.regs.dr().read().dr().bits() as u8;
             }
         }
 
@@ -551,7 +503,7 @@ where
         channel: DmaChannel,
         channel_cfg: ChannelCfg,
         dma_periph: dma::DmaPeriph,
-    ) {
+    ) -> Result<()> {
         let (ptr, len) = (buf.as_ptr(), buf.len());
 
         // To map a DMA channel for USART transmission, use
@@ -598,7 +550,7 @@ where
                     dma::DataSize::S8,
                     dma::DataSize::S8,
                     channel_cfg,
-                );
+                )
             }
             #[cfg(dma2)]
             dma::DmaPeriph::Dma2 => {
@@ -613,7 +565,7 @@ where
                     dma::DataSize::S8,
                     dma::DataSize::S8,
                     channel_cfg,
-                );
+                )
             }
         }
 
@@ -644,7 +596,7 @@ where
         channel: DmaChannel,
         channel_cfg: ChannelCfg,
         dma_periph: dma::DmaPeriph,
-    ) {
+    ) -> Result<()> {
         let (ptr, len) = (buf.as_mut_ptr(), buf.len());
 
         #[cfg(any(feature = "f3", feature = "l4"))]
@@ -679,7 +631,7 @@ where
                     dma::DataSize::S8,
                     dma::DataSize::S8,
                     channel_cfg,
-                );
+                )
             }
             #[cfg(dma2)]
             dma::DmaPeriph::Dma2 => {
@@ -694,7 +646,7 @@ where
                     dma::DataSize::S8,
                     dma::DataSize::S8,
                     channel_cfg,
-                );
+                )
             }
         }
 
@@ -712,7 +664,7 @@ where
         // When the number of data transfers programmed in the DMA Controller is reached, the DMA
         // controller generates an interrupt on the DMA channel interrupt vector.
     }
-    //
+
     // /// Flush the transmit buffer.
     // pub fn flush(&self) {
     //     #[cfg(not(feature = "f4"))]
@@ -725,13 +677,16 @@ where
     /// Enable a specific type of interrupt. See G4 RM, Table 349: USART interrupt requests.
     /// If `Some`, the inner value of `CharDetect` sets the address of the char to match.
     /// If `None`, the interrupt is enabled without changing the char to match.
-    pub fn enable_interrupt(&mut self, interrupt: UsartInterrupt) {
+    pub fn enable_interrupt(&mut self, interrupt: UsartInterrupt) -> Result<()> {
         match interrupt {
             UsartInterrupt::CharDetect(char_wrapper) => {
                 if let Some(char) = char_wrapper {
                     // Disable the UART to allow writing the `add` and `addm7` bits
                     cr1!(self.regs).modify(|_, w| w.ue().clear_bit());
-                    while cr1!(self.regs).read().ue().bit_is_set() {}
+                    bounded_loop!(
+                        cr1!(self.regs).read().ue().bit_is_set(),
+                        Error::RegisterUnchanged
+                    );
 
                     // Enable character-detecting UART interrupt
                     cr1!(self.regs).modify(|_, w| w.cmie().bit(true));
@@ -744,7 +699,10 @@ where
                     });
 
                     cr1!(self.regs).modify(|_, w| w.ue().bit(true));
-                    while cr1!(self.regs).read().ue().bit_is_clear() {}
+                    bounded_loop!(
+                        cr1!(self.regs).read().ue().bit_is_clear(),
+                        Error::RegisterUnchanged
+                    );
                 }
 
                 cr1!(self.regs).modify(|_, w| w.cmie().bit(true));
@@ -794,6 +752,7 @@ where
                 cr1!(self.regs).modify(|_, w| w.txeie().bit(true));
             }
         }
+        Ok(())
     }
 
     #[cfg(not(feature = "f4"))]
@@ -937,7 +896,7 @@ where
         }
     }
 
-    fn check_status(&mut self) -> Result<(), UartError> {
+    fn check_status(&mut self) -> core::result::Result<(), UsartError> {
         cfg_if! {
             if #[cfg(feature = "f4")] {
                 let status = self.regs.sr().read();
@@ -946,11 +905,11 @@ where
             }
         }
         let mut result = if status.pe().bit_is_set() {
-            Err(UartError::Parity)
+            Err(UsartError::Parity)
         } else if status.fe().bit_is_set() {
-            Err(UartError::Framing)
+            Err(UsartError::Framing)
         } else if status.ore().bit_is_set() {
-            Err(UartError::Overrun)
+            Err(UsartError::Overrun)
         } else {
             Ok(())
         };
@@ -963,12 +922,12 @@ where
             feature = "g061"
         )))]
         if status.nf().bit_is_set() {
-            result = Err(UartError::Noise);
+            result = Err(UsartError::Noise);
         }
 
         #[cfg(any(feature = "c0", feature = "g050", feature = "g051", feature = "g061"))]
         if status.ne().bit_is_set() {
-            result = Err(UartError::Noise);
+            result = Err(UsartError::Noise);
         }
 
         if result.is_err() {
@@ -997,24 +956,12 @@ where
 
 #[cfg(feature = "embedded_hal")]
 mod embedded_io_impl {
-    use embedded_io::*;
+    use embedded_io::{ErrorType, Read, ReadReady, Write, WriteReady};
 
     use super::*;
 
-    impl Error for UartError {
-        fn kind(&self) -> ErrorKind {
-            match self {
-                UartError::Framing => ErrorKind::Other,
-                UartError::Noise => ErrorKind::Other,
-                UartError::Overrun => ErrorKind::OutOfMemory,
-                UartError::Parity => ErrorKind::InvalidData,
-                UartError::Hardware => ErrorKind::TimedOut,
-            }
-        }
-    }
-
     impl<R> ErrorType for Usart<R> {
-        type Error = UartError;
+        type Error = crate::error::Error;
     }
 
     impl<R> Read for Usart<R>
@@ -1022,7 +969,7 @@ mod embedded_io_impl {
         R: Deref<Target = pac::usart1::RegisterBlock> + RccPeriph + BaudPeriph,
         Usart<R>: ReadReady,
     {
-        fn read(&mut self, mut buf: &mut [u8]) -> Result<usize, Self::Error> {
+        fn read(&mut self, mut buf: &mut [u8]) -> core::result::Result<usize, Self::Error> {
             // Block until at least one byte can be read:
             while !self.read_ready()? {
                 cortex_m::asm::nop();
@@ -1042,10 +989,14 @@ mod embedded_io_impl {
     where
         R: Deref<Target = pac::usart1::RegisterBlock> + RccPeriph + BaudPeriph,
     {
-        fn read_ready(&mut self) -> Result<bool, Self::Error> {
+        fn read_ready(&mut self) -> core::result::Result<bool, Self::Error> {
             self.check_status()?;
             cfg_if! {
-                if #[cfg(feature = "h5")] {
+                if #[cfg(any(
+                    feature = "h5",
+                    feature = "c0",
+                    feature = "g050", feature = "g051", feature = "g061")
+                )] {
                     let ready = self.regs.isr().read().rxfne().bit_is_set();
                 } else if #[cfg(feature = "f4")] {
                     let ready = self.regs.sr().read().rxne().bit_is_set();
@@ -1061,7 +1012,7 @@ mod embedded_io_impl {
     where
         R: Deref<Target = pac::usart1::RegisterBlock> + RccPeriph + BaudPeriph,
     {
-        fn write(&mut self, mut buf: &[u8]) -> Result<usize, Self::Error> {
+        fn write(&mut self, mut buf: &[u8]) -> core::result::Result<usize, Self::Error> {
             // Block until at least one byte can be written:
             while !self.write_ready()? {
                 cortex_m::asm::nop();
@@ -1076,7 +1027,7 @@ mod embedded_io_impl {
             Ok(buf_len - buf.len())
         }
 
-        fn flush(&mut self) -> Result<(), Self::Error> {
+        fn flush(&mut self) -> core::result::Result<(), Self::Error> {
             #[cfg(not(feature = "f4"))]
             while isr!(self.regs).read().tc().bit_is_clear() {}
             #[cfg(feature = "f4")]
@@ -1089,9 +1040,9 @@ mod embedded_io_impl {
     where
         R: Deref<Target = pac::usart1::RegisterBlock> + RccPeriph + BaudPeriph,
     {
-        fn write_ready(&mut self) -> Result<bool, Self::Error> {
+        fn write_ready(&mut self) -> core::result::Result<bool, Self::Error> {
             cfg_if! {
-                if #[cfg(feature = "h5")] {
+                if #[cfg(any(feature = "h5", feature = "g0"))] {
                     let ready = self.regs.isr().read().txfe().bit_is_set();
                 } else if #[cfg(feature = "f4")] {
                     let ready = self.regs.sr().read().txe().bit_is_set();

--- a/src/usart.rs
+++ b/src/usart.rs
@@ -361,10 +361,9 @@ where
             cfg_if! {
                 if #[cfg(any(
                     feature = "h5",
-                    feature = "g050",
-                    feature = "g051",
-                    feature = "g061"
-                ))] {
+                    feature = "c0",
+                    feature = "g050", feature = "g051", feature = "g061")
+                )] {
                     bounded_loop!(
                         isr!(self.regs).read().txfe().bit_is_clear(),
                         Error::RegisterUnchanged
@@ -438,10 +437,9 @@ where
             cfg_if! {
                 if #[cfg(any(
                     feature = "h5",
-                    feature = "g050",
-                    feature = "g051",
-                    feature = "g061"
-                ))] {
+                    feature = "c0",
+                    feature = "g050", feature = "g051", feature = "g061")
+                )] {
                     bounded_loop!(
                         isr!(self.regs).read().rxfne().bit_is_clear(),
                         Error::RegisterUnchanged
@@ -1042,7 +1040,11 @@ mod embedded_io_impl {
     {
         fn write_ready(&mut self) -> core::result::Result<bool, Self::Error> {
             cfg_if! {
-                if #[cfg(any(feature = "h5", feature = "g0"))] {
+                if #[cfg(any(
+                    feature = "h5",
+                    feature = "c0",
+                    feature = "g050", feature = "g051", feature = "g061")
+                )] {
                     let ready = self.regs.isr().read().txfe().bit_is_set();
                 } else if #[cfg(feature = "f4")] {
                     let ready = self.regs.sr().read().txe().bit_is_set();


### PR DESCRIPTION
This PR bounds all while loops (except those used in embedded_hal definitions) using the new `util::bounded_loop!` macro. There may be more places which should wait for registers being set, but that can come later.

All different error-types were also consolidated into a new Error-type.

Many functions now return Results as opposed to before, so this is very much a breaking API change.

This PR has not yet been tested on hardware, but has been successfully compiled for each family.