### PR TITLE
Re-enable TIM2 on wb55

### DIFF
--- a/src/timer.rs
+++ b/src/timer.rs
@@ -2269,7 +2269,6 @@ cfg_if! {
         feature = "f410",
         feature = "g070",
         feature = "l5", // todo PAC bug?
-        feature = "wb55", // todo PAC bug?
         feature = "g030",
         feature = "g031",
         feature = "g050",


### PR DESCRIPTION
TIM2 on wb55 seems to exist in latest PAC