### PR TITLE
Automatically set MOE bit when enabling output compare

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,9 +339,6 @@ library.
 - Low power modes beyond csleep and cstop aren't implemented for H7
 - WB and WL are missing features relating to second core operations
 - L4+ MCUs not supported
-- If using PWM (or output compare in general) on an Advanced control timer (e.g. TIM1 or 8),
-you must manually set the `TIMx_BDTR` register, `MOE` bit. On C0, this also affects TIM15, TIM16, 
-and TIM17.
 - Octospi implementation is broken
 - G0 and H7: Only FDCAN1 is implemented.
 - H5 is missing a lot of functionality, including DMA.

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -1526,7 +1526,7 @@ macro_rules! cc_4_channels {
 
 #[cfg(any(feature = "g0", feature = "g4", feature = "c0"))]
 macro_rules! cc_2_channels {
-    ($TIMX:ident, $res:ident, $(, $bdtr:ident)?) => {
+    ($TIMX:ident, $res:ident $(, $bdtr:ident)?) => {
         impl Timer<pac::$TIMX> {
             /// Function that allows us to set direction only on timers that have this option.
             fn set_dir(&mut self) {

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -689,8 +689,6 @@ macro_rules! make_timer {
 
 
             /// Enables PWM output for a given channel and output compare, with an initial duty cycle, in Hz.
-            /// Note: On TIM1 and TIM8, (And others if on C0), you must manually set the `bdtr` register,
-            /// `moe` bit.
             pub fn enable_pwm_output(
                 &mut self,
                 channel: TimChannel,
@@ -1263,8 +1261,6 @@ macro_rules! cc_4_channels {
             // todo: more advanced PWM modes. Asymmetric, combined, center-aligned etc.
 
             /// Set Output Compare Mode. See docs on the `OutputCompare` enum.
-            /// Note: On TIM1 and TIM8, (And others if on C0), you must manually set the `bdtr` register,
-            /// `moe` bit.
             pub fn set_output_compare(&mut self, channel: TimChannel, mode: OutputCompare) {
                 match channel {
                     TimChannel::C1 => {
@@ -1303,10 +1299,6 @@ macro_rules! cc_4_channels {
                         });
                     }
                 }
-
-                $(
-                    self.regs.$bdtr().modify(|_, w| w.moe().set_bit());
-                )?
             }
 
             /// Return the set duty period for a given channel. Divide by `get_max_duty()`
@@ -1438,6 +1430,8 @@ macro_rules! cc_4_channels {
             }
 
             /// Set Capture Compare mode in output mode. See docs on the `CaptureCompare` enum.
+            /// 
+            /// Note: Also sets MOE bit BDTR register for timers that have it.
             pub fn set_capture_compare_output(
                 &mut self,
                 channel: TimChannel,
@@ -1465,6 +1459,10 @@ macro_rules! cc_4_channels {
                         .ccmr2_output()
                         .modify(unsafe { |_, w| w.cc4s().bits(mode as u8) }),
                 };
+
+                $(
+                    self.regs.$bdtr().modify(|_, w| w.moe().set_bit());
+                )?
             }
 
             /// Set Capture Compare mode in input mode. See docs on the `CaptureCompare` enum.
@@ -1576,8 +1574,6 @@ macro_rules! cc_2_channels {
             }
 
             /// Set Output Compare Mode. See docs on the `OutputCompare` enum.
-            /// Note: On TIM1 and TIM8, (And others if on C0), you must manually set the `bdtr` register,
-            /// `moe` bit.
             pub fn set_output_compare(&mut self, channel: TimChannel, mode: OutputCompare) {
                 match channel {
                     TimChannel::C1 => {
@@ -1697,6 +1693,8 @@ macro_rules! cc_2_channels {
             }
 
             /// Set Capture Compare mode in output mode. See docs on the `CaptureCompare` enum.
+            /// 
+            /// Note: Also sets MOE bit BDTR register for timers that have it.
             pub fn set_capture_compare_output(&mut self, channel: TimChannel, mode: CaptureCompare) {
                 self.disable_capture_compare(channel);
 
@@ -1712,6 +1710,10 @@ macro_rules! cc_2_channels {
                         .modify(unsafe { |_, w| w.cc2s().bits(mode as u8) }),
                     _ => panic!()
                 };
+
+                $(
+                    self.regs.$bdtr().modify(|_, w| w.moe().set_bit());
+                )?
             }
 
             /// Set Capture Compare mode in input mode. See docs on the `CaptureCompare` enum.
@@ -1802,8 +1804,6 @@ macro_rules! cc_1_channel {
             }
 
             /// Set Output Compare Mode. See docs on the `OutputCompare` enum.
-            /// Note: On TIM1 and TIM8, (And others if on C0), you must manually set the `bdtr` register,
-            /// `moe` bit.
             pub fn set_output_compare(&mut self, channel: TimChannel, mode: OutputCompare) {
                 match channel {
                     TimChannel::C1 => {
@@ -1887,6 +1887,8 @@ macro_rules! cc_1_channel {
             }
 
             /// Set Capture Compare mode in output mode. See docs on the `CaptureCompare` enum.
+            /// 
+            /// Note: Also sets MOE bit BDTR register for timers that have it.
             pub fn set_capture_compare_output(
                 &mut self,
                 channel: TimChannel,
@@ -1901,6 +1903,10 @@ macro_rules! cc_1_channel {
                         .modify(unsafe { |_, w| w.cc1s().bits(mode as u8) }),
                     _ => panic!(),
                 };
+
+                $(
+                    self.regs.$bdtr().modify(|_, w| w.moe().set_bit());
+                )?
             }
 
             /// Set Capture Compare mode in input mode. See docs on the `CaptureCompare` enum.

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -1134,7 +1134,7 @@ macro_rules! cc_slave_mode {
 // different timers.
 // Note that there's lots of DRY between these implementations.
 macro_rules! cc_4_channels {
-    ($TIMX:ident, $res:ident) => {
+    ($TIMX:ident, $res:ident $(, $bdtr:ident)?) => {
         impl Timer<pac::$TIMX> {
             /// Function that allows us to set direction only on timers that have this option.
             pub fn set_dir(&mut self) {
@@ -1303,6 +1303,10 @@ macro_rules! cc_4_channels {
                         });
                     }
                 }
+
+                $(
+                    self.regs.$bdtr().modify(|_, w| w.moe().set_bit());
+                )?
             }
 
             /// Return the set duty period for a given channel. Divide by `get_max_duty()`
@@ -1522,7 +1526,7 @@ macro_rules! cc_4_channels {
 
 #[cfg(any(feature = "g0", feature = "g4", feature = "c0"))]
 macro_rules! cc_2_channels {
-    ($TIMX:ident, $res:ident) => {
+    ($TIMX:ident, $res:ident, $(, $bdtr:ident)?) => {
         impl Timer<pac::$TIMX> {
             /// Function that allows us to set direction only on timers that have this option.
             fn set_dir(&mut self) {
@@ -1594,6 +1598,10 @@ macro_rules! cc_2_channels {
                     }
                     _ => panic!()
                 }
+
+                $(
+                    self.regs.$bdtr().modify(|_, w| w.moe().set_bit());
+                )?
             }
 
             /// Return the set duty period for a given channel. Divide by `get_max_duty()`
@@ -1758,7 +1766,7 @@ macro_rules! cc_2_channels {
 }
 
 macro_rules! cc_1_channel {
-    ($TIMX:ident, $res:ident) => {
+    ($TIMX:ident, $res:ident $(, $bdtr:ident)?) => {
         impl Timer<pac::$TIMX> {
             /// Function that allows us to set direction only on timers that have this option.
             fn set_dir(&mut self) {} // N/A with these 1-channel timers.
@@ -1815,6 +1823,10 @@ macro_rules! cc_1_channel {
                     }
                     _ => panic!(),
                 };
+
+                $(
+                    self.regs.$bdtr().modify(|_, w| w.moe().set_bit());
+                )?
             }
 
             /// Return the set duty period for a given channel. Divide by `get_max_duty()`
@@ -2258,11 +2270,11 @@ make_timer!(TIM1, tim1, 2, u16);
 cc_slave_mode!(TIM1);
 
 #[cfg(not(any(feature = "f373", feature = "g0", feature = "g4")))]
-cc_4_channels!(TIM1, u16);
+cc_4_channels!(TIM1, u16, bdtr);
 // todo: PAC error?
 // TIM1 on G4 is nominally 16-bits, but has ~20 bits on ARR, with PAC showing 32 bits?
 #[cfg(any(feature = "g0", feature = "g4"))]
-cc_2_channels!(TIM1, u16);
+cc_2_channels!(TIM1, u16, bdtr);
 
 cfg_if! {
     if #[cfg(not(any(
@@ -2319,7 +2331,7 @@ cfg_if! {
     )))] {
         make_timer!(TIM4, tim4, 1, u32);
         cc_slave_mode!(TIM4);
-        cc_4_channels!(TIM4, u32);
+        cc_4_channels!(TIM4, u32, bdtr);
     }
 }
 
@@ -2339,7 +2351,7 @@ cfg_if! {
    ))] {
         make_timer!(TIM5, tim5, 1, u32);
         cc_slave_mode!(TIM5);
-        cc_4_channels!(TIM5, u32);
+        cc_4_channels!(TIM5, u32, bdtr);
    }
 }
 
@@ -2354,7 +2366,7 @@ cfg_if! {
     ))] {
         make_timer!(TIM8, tim8, 2, u16);
         cc_slave_mode!(TIM8);
-        cc_4_channels!(TIM8, u16);
+        cc_4_channels!(TIM8, u16, bdtr);
     }
 }
 
@@ -2363,7 +2375,7 @@ cfg_if! {
     if #[cfg(feature = "g4")] {
         make_timer!(TIM8, tim8, 2, u32);
         cc_slave_mode!(TIM8);
-        cc_4_channels!(TIM8, u32);
+        cc_4_channels!(TIM8, u32, bdtr);
     }
 }
 
@@ -2398,19 +2410,19 @@ cfg_if! {
         make_timer!(TIM15, tim15, 2, u16);
         cc_slave_mode!(TIM15);
         // todo: TIM15 on some variant has 2 channels (Eg H7). On others, like L4x3, it appears to be 1.
-        cc_1_channel!(TIM15, u16);
+        cc_1_channel!(TIM15, u16, bdtr);
     }
 }
 
 #[cfg(not(any(feature = "f4", feature = "c0")))]
 make_timer!(TIM16, tim16, 2, u16);
 #[cfg(not(any(feature = "f4", feature = "c0")))]
-cc_1_channel!(TIM16, u16);
+cc_1_channel!(TIM16, u16, bdtr);
 
 #[cfg(feature = "c0")]
 make_timer!(TIM16, tim16, 2, u32);
 #[cfg(feature = "c0")]
-cc_1_channel!(TIM16, u32);
+cc_1_channel!(TIM16, u32, bdtr);
 
 cfg_if! {
     if #[cfg(not(any(
@@ -2421,7 +2433,7 @@ cfg_if! {
         feature = "f4",
     )))] {
         make_timer!(TIM17, tim17, 2, u16);
-        cc_1_channel!(TIM17, u16);
+        cc_1_channel!(TIM17, u16, bdtr);
     }
 }
 

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -2331,7 +2331,7 @@ cfg_if! {
     )))] {
         make_timer!(TIM4, tim4, 1, u32);
         cc_slave_mode!(TIM4);
-        cc_4_channels!(TIM4, u32, bdtr);
+        cc_4_channels!(TIM4, u32);
     }
 }
 
@@ -2351,7 +2351,7 @@ cfg_if! {
    ))] {
         make_timer!(TIM5, tim5, 1, u32);
         cc_slave_mode!(TIM5);
-        cc_4_channels!(TIM5, u32, bdtr);
+        cc_4_channels!(TIM5, u32);
    }
 }
 


### PR DESCRIPTION
As discussed in https://github.com/David-OConnor/stm32-hal/issues/135, fixes https://github.com/David-OConnor/stm32-hal/issues/42.

I automatically set the MOE bit for timers that have it.

Tested on C071.

Open questions:
- [ ] Where should the MOE bit be set? I see three reasonable options:
  - inside `set_output_compare`
  - inside `set_capture_compare_output`, when mode is set to output
  - in a separate method that is called by `enable_pwm_output`
