### PR TITLE
Rename Pull::Dn to Pull::Down

### DIFF
--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -90,7 +90,7 @@ pub enum OutputSpeed {
 pub enum Pull {
     Floating = 0b00,
     Up = 0b01,
-    Dn = 0b10,
+    Down = 0b10,
 }
 
 #[derive(Copy, Clone)]


### PR DESCRIPTION
I found it confusing that `Pull::Up` and `Pull::Floating` use the full names, but pull-down was shortened to `Pull::Dn`. This PR makes it consistent with the others.