### PR TITLE
L4 family GPIO interrupt configuration

### DIFF
--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -363,10 +363,9 @@ macro_rules! set_exti {
                                 exti.c1imr1().modify(|_, w| w.[<mr $num>]().bit(true));
                             } else if #[cfg(any(feature = "g4", feature = "wb", feature = "wl"))] {
                                 exti.imr1().modify(|_, w| w.[<im $num>]().bit(true));
+                            } else if #[cfg(feature = "l4")]{
+                                exti.imr1().modify(|_, w| w.[<mr $num>]().bit(true));
                             }
-                            // else {
-                            //     exti.imr1().modify(|_, w| w.[<mr $num>]().bit(true));
-                            // }
                         }
 
                         cfg_if! {


### PR DESCRIPTION
In the macro `gpio::set_exti` there was a commented out block that unmasked the interrupt mask for the EXTI line for the GPIO pin. I have uncommented it and placed it behind the `l4` feature since at this time I'm only aware that this is necessary for the L4 family of MCUs.

This is mentioned on page 330 of the reference manual for the L4 family, which can be found [here](https://www.st.com/resource/en/reference_manual/rm0394-stm32l41xxx42xxx43xxx44xxx45xxx46xxx-advanced-armbased-32bit-mcus-stmicroelectronics.pdf).