### PR TITLE
Add ADC triggers for L4xx devices

### DIFF
--- a/src/adc.rs
+++ b/src/adc.rs
@@ -101,7 +101,7 @@ cfg_if! {
             Tim8Trgo = 0b1110,
             Exti11   = 0b1111,
         }
-    } else if #[cfg(feature = "l4")] {
+    } else if #[cfg(any(feature = "l4x5", feature="l4x6"))] {
         /// Select a trigger. Sets CFGR reg, EXTSEL field. See L4 RM, table 108: External triggers for regular channels
         #[derive(Clone, Copy)]
         #[repr(u8)]


### PR DESCRIPTION
Sourced from RM0351 Rev 10 (STM32L47xxx, STM32L48xxx, STM32L49xxx and STM32L4Axxx
advanced Arm®-based 32-bit MCUs). 
Tested on STM32L475VGT6 using the ```STM32L4x6``` feature

<img width="632" height="766" alt="image" src="https://github.com/user-attachments/assets/ec8eb83b-80a1-4461-b363-cb057d573d2a" />
