### PR TITLE
Don't set rcc.ahb2rstr.adcrst bit when initializing ADCs on L4x5/L4x6

### DIFF
--- a/src/adc.rs
+++ b/src/adc.rs
@@ -449,6 +449,8 @@ macro_rules! hal {
                             } else if #[cfg(any(feature = "g4"))] {
                                 rcc.ahb2enr().modify(|_, w| w.adc12en().bit(true));
                                 // rcc_en_reset!(ahb2, [<adc $rcc_num>], rcc);
+                            } else if #[cfg(any(feature = "l4x5", feature="l4x6"))] {
+                                rcc.ahb2enr().modify(|_, w| w.adcen().bit(true));
                             } else {  // ie L4, L5, G0(?)
                                 rcc_en_reset!(ahb2, adc, rcc);
                             }


### PR DESCRIPTION
When configuring multiple ADCs (i.e. ADC1 and ADC2) via the new_adc function, all but the last ADC will be reset. This is because the library calls `rcc_en_reset` by default, even though it isn't appropriate in this instance. Like the h7 and g4 code, I've added code to manually set the enable register rather than calling the rcc_en_reset macro.